### PR TITLE
[change] expose an amount's data

### DIFF
--- a/src/Resources/EmbeddedResources/Amount.php
+++ b/src/Resources/EmbeddedResources/Amount.php
@@ -28,13 +28,13 @@ use UnzerSDK\Resources\AbstractUnzerResource;
 
 class Amount extends AbstractUnzerResource
 {
-    private $total = 0.0;
-    private $charged = 0.0;
-    private $canceled = 0.0;
-    private $remaining = 0.0;
+    protected $total = 0.0;
+    protected $charged = 0.0;
+    protected $canceled = 0.0;
+    protected $remaining = 0.0;
 
     /** @var string $currency */
-    private $currency;
+    protected $currency;
 
     //<editor-fold desc="Getters/Setters">
 

--- a/test/unit/Resources/EmbeddedResources/AmountTest.php
+++ b/test/unit/Resources/EmbeddedResources/AmountTest.php
@@ -55,4 +55,20 @@ class AmountTest extends BasePaymentTest
         $this->assertEquals(3.3, $amount->getCharged());
         $this->assertEquals(4.4, $amount->getRemaining());
     }
+
+    /**
+     * Verify exposing
+     *
+     * @test
+     *
+     */
+    public function exposeShouldNotBeEmpty(): void
+    {
+        $amount = new Amount();
+
+        $resp = ['total' => 1.1, 'canceled' => 2.2, 'charged' => 3.3, 'remaining' => 4.4, 'currency' => 'MyCurrency'];
+        $amount->handleResponse((object)$resp);
+
+        $this->assertEquals($resp, $amount->expose());
+    }
 }


### PR DESCRIPTION
Dear maintainers, thank you for providing a PHP SDK library. :+1: 

For debugging stuff I'd like to dump some basic info about the payment resource. After digging deeper into the library I've found the following way:
```php
$payment = container()->get(UnzerClient::class)->fetchPayment($id);
dump($payment->expose());
```
An above solution works quite good but there is one case which makes me confused. The payment's amount is empty.

**Given**

![image](https://user-images.githubusercontent.com/1732227/122534359-ba6b6d00-d022-11eb-90dd-75de849fe3f3.png)

**Expected**

![image](https://user-images.githubusercontent.com/1732227/122534441-ceaf6a00-d022-11eb-98da-b42ea308f68b.png)

