### PR TITLE
Umcs 52/php8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 *   Enable PHP 8.
 *   Allow phpUnit version 8.x. in composer dev requirements, and adjust tests accordingly.
 
-###
-Changed
+### Changed
 *   `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.
 *   Several minor changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [1.1.3.0](https://github.com/unzerdev/php-sdk/compare/1.1.2.0..1.1.3.0)
 ### Added
 *   Enable PHP 8.0 compatibility.
-*   Allow PHPUnit version 8.x and 9.x in composer dev requirements, and adjust tests accordingly.
+*   Allow PHPUnit version 8.x and 9.x in composer dev requirementsK and adjust tests accordingly.
 
 ### Changed
 *   `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.3.0](https://github.com/unzerdev/php-sdk/compare/1.1.2.0..1.1.3.0)
+### Added
+* Enable PHP 8 support
+    * Allow phpUnit version 8.x. in dev requirements.
+    * `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.
+
 ## [1.1.2.0](https://github.com/unzerdev/php-sdk/compare/1.1.1.1..1.1.2.0)
 ### Added
 *   Introduce the payment type Applepay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [1.1.3.0](https://github.com/unzerdev/php-sdk/compare/1.1.2.0..1.1.3.0)
 ### Added
-* Enable PHP 8 support
-    * Allow phpUnit version 8.x. in dev requirements.
-    * `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.
+* Enable PHP 8.
+* Allow phpUnit version 8.x. in composer dev requirements, and adjust tests accordingly.
+
+###
+Changed
+* `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.
+*   Several minor changes.
 
 ## [1.1.2.0](https://github.com/unzerdev/php-sdk/compare/1.1.1.1..1.1.2.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [1.1.3.0](https://github.com/unzerdev/php-sdk/compare/1.1.2.0..1.1.3.0)
 ### Added
-* Enable PHP 8.
-* Allow phpUnit version 8.x. in composer dev requirements, and adjust tests accordingly.
+*   Enable PHP 8.
+*   Allow phpUnit version 8.x. in composer dev requirements, and adjust tests accordingly.
 
 ###
 Changed
-* `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.
+*   `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.
 *   Several minor changes.
 
 ## [1.1.2.0](https://github.com/unzerdev/php-sdk/compare/1.1.1.1..1.1.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [1.1.3.0](https://github.com/unzerdev/php-sdk/compare/1.1.2.0..1.1.3.0)
 ### Added
-*   Enable PHP 8.
-*   Allow phpUnit version 8.x. in composer dev requirements, and adjust tests accordingly.
+*   Enable PHP 8.0 compatibility.
+*   Allow PHPUnit version 8.x and 9.x in composer dev requirements, and adjust tests accordingly.
 
 ### Changed
 *   `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [1.1.3.0](https://github.com/unzerdev/php-sdk/compare/1.1.2.0..1.1.3.0)
 ### Added
 *   Enable PHP 8.0 compatibility.
-*   Allow PHPUnit version 8.x and 9.x in composer dev requirementsK and adjust tests accordingly.
+*   Allow PHPUnit version 8.x and 9.x in composer dev requirements and adjust tests accordingly.
 
 ### Changed
 *   `\UnzerSDK\Services\HttpService::handleErrors` explicitly casts response code to int, to ensure same behaviour on all PHP versions.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": ">6.5 <9.0",
+    "phpunit/phpunit": ">6.5 <10.0",
     "friendsofphp/php-cs-fixer": "^2.0"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
   "minimum-stability": "stable",
   "license": "Apache-2.0",
   "require": {
-    "php": "~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+    "php": "~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0",
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": ">6.5 <8.0",
+    "phpunit/phpunit": ">6.5 <9.0",
     "friendsofphp/php-cs-fixer": "^2.0"
   },
   "suggest": {

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -173,7 +173,7 @@ class HttpService
         }
 
         $responseObject = json_decode($response, false);
-        if ($responseCode >= 400 || isset($responseObject->errors)) {
+        if (!is_numeric($responseCode) || (int)$responseCode >= 400 || isset($responseObject->errors)) {
             $code            = null;
             $errorId         = null;
             $customerMessage = $code;

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -63,7 +63,7 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
     public const BASE_URL = 'api.unzer.com';
     public const API_VERSION = 'v1';
     public const SDK_TYPE = 'UnzerPHP';
-    public const SDK_VERSION = '1.1.2.0';
+    public const SDK_VERSION = '1.1.3.0';
 
     /** @var string $key */
     private $key;

--- a/test/BasePaymentTest.php
+++ b/test/BasePaymentTest.php
@@ -333,4 +333,16 @@ class BasePaymentTest extends TestCase
     }
 
     //</editor-fold>
+
+    /** Assertion that all elements of an array (needle) do exist in a haystack.
+     *
+     * @param array $needle
+     * @param array $haystack
+     */
+    protected function assertArrayContains(array $needle, array $haystack): void
+    {
+        foreach ($needle as $key => $value) {
+            $this->assertEquals($value, $haystack[$key]);
+        }
+    }
 }

--- a/test/integration/PaymentTypes/InstallmentSecuredTest.php
+++ b/test/integration/PaymentTypes/InstallmentSecuredTest.php
@@ -35,7 +35,6 @@ use UnzerSDK\Resources\CustomerFactory;
 use UnzerSDK\Resources\EmbeddedResources\Address;
 use UnzerSDK\Resources\InstalmentPlan;
 use UnzerSDK\Resources\PaymentTypes\InstallmentSecured;
-use UnzerSDK\Resources\TransactionTypes\Authorization;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use UnzerSDK\test\BaseIntegrationTest;
 use function count;
@@ -62,7 +61,7 @@ class InstallmentSecuredTest extends BaseIntegrationTest
 
         $ins = new InstallmentSecured($selectedPlan, 'DE46940594210000012345', 'Manuel Weißmann');
         $this->unzer->createPaymentType($ins);
-        $this->assertArraySubset($selectedPlan->expose(), $ins->expose());
+        $this->assertArrayContains($selectedPlan->expose(), $ins->expose());
 
         $fetchedIns = $this->unzer->fetchPaymentType($ins->getId());
         $this->assertEquals($ins->expose(), $fetchedIns->expose());
@@ -219,7 +218,7 @@ class InstallmentSecuredTest extends BaseIntegrationTest
         $this->assertCount($selectedPlan->getNumberOfRates(), $selectedPlan->getInstallmentRates(), 'The number of rates should equal the actual rate count.');
         $ins = new InstallmentSecured($selectedPlan, 'DE46940594210000012345', 'Manuel Weißmann', $yesterday, 'COBADEFFXXX', $yesterday, $this->getTomorrowsTimestamp());
         $this->unzer->createPaymentType($ins);
-        $this->assertArraySubset($selectedPlan->expose(), $ins->expose());
+        $this->assertArrayContains($selectedPlan->expose(), $ins->expose());
     }
 
     /**

--- a/test/unit/Resources/AbstractUnzerResourceTest.php
+++ b/test/unit/Resources/AbstractUnzerResourceTest.php
@@ -399,7 +399,7 @@ class AbstractUnzerResourceTest extends BasePaymentTest
         // additionalAttributes
         $ppg = new Paypage(1.23456789, 'EUR', self::RETURN_URL);
         $ppg->setEffectiveInterestRate(12.3456789);
-        $this->assertArraySubset(['additionalAttributes' => ['effectiveInterestRate' => 12.3457]], $ppg->expose());
+        $this->assertEquals(12.3457, $ppg->expose()['additionalAttributes']['effectiveInterestRate']);
         $this->assertEquals(12.3457, $ppg->getEffectiveInterestRate());
     }
 
@@ -417,14 +417,14 @@ class AbstractUnzerResourceTest extends BasePaymentTest
 
         // then
         $this->assertEquals(123.4567, $paypage->getEffectiveInterestRate());
-        $this->assertArraySubset(['additionalAttributes' => ['effectiveInterestRate' => 123.4567]], $paypage->expose());
+        $this->assertEquals(123.4567, $paypage->expose()['additionalAttributes']['effectiveInterestRate']);
 
         // when
         $paypage->handleResponse((object)['additionalAttributes' => ['effectiveInterestRate' => 1234.567]]);
 
         // then
         $this->assertEquals(1234.567, $paypage->getEffectiveInterestRate());
-        $this->assertArraySubset(['additionalAttributes' => ['effectiveInterestRate' => 1234.567]], $paypage->expose());
+        $this->assertEquals(1234.567, $paypage->expose()['additionalAttributes']['effectiveInterestRate']);
     }
 
     //<editor-fold desc="Data Providers">

--- a/test/unit/Resources/KeypairTest.php
+++ b/test/unit/Resources/KeypairTest.php
@@ -77,7 +77,7 @@ class KeypairTest extends BasePaymentTest
         $keypair->handleResponse($testResponse);
 
         // then
-        $this->assertArraySubset($paymentTypes, $keypair->getPaymentTypes());
+        $this->assertArrayContains($paymentTypes, $keypair->getPaymentTypes());
         $this->assertEquals('s-pub-1234', $keypair->getPublicKey());
         $this->assertEquals('s-priv-4321', $keypair->getPrivateKey());
         $this->assertTrue($keypair->isCof());

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -444,7 +444,7 @@ class HttpServiceTest extends BasePaymentTest
             'Prod' => [EnvironmentService::ENV_VAR_VALUE_PROD_ENVIRONMENT, 'https://api.unzer.com/v1'],
             'Stg' => [EnvironmentService::ENV_VAR_VALUE_STAGING_ENVIRONMENT, 'https://stg-api.unzer.com/v1'],
             'else' => ['something else', 'https://api.unzer.com/v1'],
-            'undefined' => [false, 'https://api.unzer.com/v1']
+            'undefined' => ['', 'https://api.unzer.com/v1']
         ];
     }
 

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -127,7 +127,7 @@ class HttpServiceTest extends BasePaymentTest
         ];
         $adapterMock->expects($this->once())->method('setHeaders')->with($headers);
         $adapterMock->expects($this->once())->method('execute')->willReturn('myResponseString');
-        $adapterMock->expects($this->once())->method('getResponseCode')->willReturn('myResponseCode');
+        $adapterMock->expects($this->once())->method('getResponseCode')->willReturn('399');
         $adapterMock->expects($this->once())->method('close');
 
         $httpServiceMock->method('getAdapter')->willReturn($adapterMock);
@@ -254,7 +254,7 @@ class HttpServiceTest extends BasePaymentTest
     }
 
     /**
-     * Verify handleErrors will throw Exception if responseCode is greaterOrEqual to 400.
+     * Verify handleErrors will throw Exception if responseCode is greaterOrEqual to 400 or is not a number.
      *
      * @test
      * @dataProvider responseCodeProvider
@@ -385,7 +385,7 @@ class HttpServiceTest extends BasePaymentTest
         $adapterMock->expects($this->once())->method('init')->with($apiUrl, self::anything(), self::anything());
         $resource = (new DummyResource())->setParentResource(new Unzer('s-priv-MyTestKey'));
         $adapterMock->method('execute')->willReturn('myResponseString');
-        $adapterMock->method('getResponseCode')->willReturn('myResponseCode');
+        $adapterMock->method('getResponseCode')->willReturn('42');
 
         $envSrvMock = $this->getMockBuilder(EnvironmentService::class)->setMethods(['getPapiEnvironment'])->getMock();
         $envSrvMock->method('getPapiEnvironment')->willReturn($environment);
@@ -417,7 +417,8 @@ class HttpServiceTest extends BasePaymentTest
             '404' => ['404'],
             '500' => ['500'],
             '600' => ['600'],
-            '1000' => ['1000']
+            '1000' => ['1000'],
+            'Response code not a number' => ['myResponseCode']
         ];
     }
 


### PR DESCRIPTION
- Enable php 8 in comoser.
- Enable PhpUnit version 8 and higher. (required for PHP)
- Replace use of deprecated methods in PhpUnit tests.