### PR TITLE
[noticket] Fix phpDoc for charge method

### DIFF
--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -684,8 +684,8 @@ class Payment extends AbstractUnzerResource
     /**
      * Performs a Charge transaction on the payment.
      *
-     * @param null $amount   The amount to be charged.
-     * @param null $currency The currency of the charged amount.
+     * @param float|null  $amount   The amount to be charged.
+     * @param string|null $currency The currency of the charged amount.
      *
      * @return Charge|AbstractUnzerResource The resulting Charge object.
      *


### PR DESCRIPTION
These misspelled types for the parameters are causing a phpstan error when using the charge method with an amount and/or currency.