### PR TITLE
Provide clientIp being set via unzer facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [1.1.6.0](https://github.com/unzerdev/php-sdk/compare/1.1.5.0..1.1.6.0)
 ### Added
 * Add payment type Paylater Invoice.
-* Allow manually setting of clientIp.
+* Allow setting the clientIp manually.
+
+### Changed
+*   Several minor improvements.
 
 ## [1.1.5.0](https://github.com/unzerdev/php-sdk/compare/1.1.4.2..1.1.5.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [1.1.6.0](https://github.com/unzerdev/php-sdk/compare/1.1.5.0..1.1.6.0)
 ### Added
 * Add payment type Paylater Invoice.
+* Allow manually setting of clientIp.
 
 ## [1.1.5.0](https://github.com/unzerdev/php-sdk/compare/1.1.4.2..1.1.5.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Allow setting the clientIp manually.
 
 ### Changed
-*   Several minor improvements.
+* Add "geoLocation" property to all payment type classes.
+* Several minor improvements.
 
 ## [1.1.5.0](https://github.com/unzerdev/php-sdk/compare/1.1.4.2..1.1.5.0)
 ### Added

--- a/src/Constants/ApiResponseCodes.php
+++ b/src/Constants/ApiResponseCodes.php
@@ -71,6 +71,7 @@ class ApiResponseCodes
     public const API_ERROR_FIELD_IS_MISSING                            = 'API.710.200.100';
 
     public const CORE_ERROR_INVALID_OR_MISSING_LOGIN                   = 'COR.100.300.600';
+    public const CORE_INVALID_IP_NUMBER                                = 'COR.100.900.401';
     public const CORE_ERROR_INSURANCE_ALREADY_ACTIVATED                = 'COR.700.400.800';
 
     public const SDM_ERROR_CURRENT_INSURANCE_EVENT                     = 'SDM.CURRENT_INSURANCE_EVENT';

--- a/src/Resources/PaymentTypes/Applepay.php
+++ b/src/Resources/PaymentTypes/Applepay.php
@@ -35,7 +35,6 @@ class Applepay extends BasePaymentType
 {
     use CanDirectCharge;
     use CanAuthorize;
-    use HasGeoLocation;
 
     /** @var string|null $applicationExpirationDate */
     private $applicationExpirationDate;

--- a/src/Resources/PaymentTypes/Applepay.php
+++ b/src/Resources/PaymentTypes/Applepay.php
@@ -29,7 +29,6 @@ use UnzerSDK\Adapter\HttpAdapterInterface;
 use UnzerSDK\Resources\EmbeddedResources\ApplePayHeader;
 use UnzerSDK\Traits\CanAuthorize;
 use UnzerSDK\Traits\CanDirectCharge;
-use UnzerSDK\Traits\HasGeoLocation;
 
 class Applepay extends BasePaymentType
 {

--- a/src/Resources/PaymentTypes/BasePaymentType.php
+++ b/src/Resources/PaymentTypes/BasePaymentType.php
@@ -26,9 +26,11 @@ namespace UnzerSDK\Resources\PaymentTypes;
 
 use UnzerSDK\Adapter\HttpAdapterInterface;
 use UnzerSDK\Resources\AbstractUnzerResource;
+use UnzerSDK\Traits\HasGeoLocation;
 
 abstract class BasePaymentType extends AbstractUnzerResource
 {
+    use HasGeoLocation;
     /**
      * Return true for invoice types.
      * This enables you to handle the invoice workflow correctly.

--- a/src/Resources/PaymentTypes/BasePaymentType.php
+++ b/src/Resources/PaymentTypes/BasePaymentType.php
@@ -31,6 +31,7 @@ use UnzerSDK\Traits\HasGeoLocation;
 abstract class BasePaymentType extends AbstractUnzerResource
 {
     use HasGeoLocation;
+
     /**
      * Return true for invoice types.
      * This enables you to handle the invoice workflow correctly.

--- a/src/Resources/PaymentTypes/Card.php
+++ b/src/Resources/PaymentTypes/Card.php
@@ -30,7 +30,6 @@ use UnzerSDK\Traits\CanAuthorize;
 use UnzerSDK\Traits\CanDirectCharge;
 use UnzerSDK\Traits\CanPayout;
 use UnzerSDK\Traits\CanRecur;
-use UnzerSDK\Traits\HasGeoLocation;
 use UnzerSDK\Validators\ExpiryDateValidator;
 use RuntimeException;
 use stdClass;

--- a/src/Resources/PaymentTypes/Card.php
+++ b/src/Resources/PaymentTypes/Card.php
@@ -41,7 +41,6 @@ class Card extends BasePaymentType
     use CanAuthorize;
     use CanPayout;
     use CanRecur;
-    use HasGeoLocation;
 
     /** @var string $number */
     protected $number;

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -269,6 +269,7 @@ class HttpService
     public function composerHttpHeaders(Unzer $unzer): array
     {
         $locale      = $unzer->getLocale();
+        $clientIp    = $unzer->getClientIp();
         $key         = $unzer->getKey();
         $httpHeaders = [
             'Authorization' => 'Basic ' . base64_encode($key . ':'),
@@ -279,6 +280,9 @@ class HttpService
         ];
         if (!empty($locale)) {
             $httpHeaders['Accept-Language'] = $locale;
+        }
+        if (!empty($clientIp)) {
+            $httpHeaders['CLIENTIP'] = $clientIp;
         }
 
         return $httpHeaders;

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -124,7 +124,7 @@ class HttpService
         // perform request
         $url     = $this->getEnvironmentUrl($uri, $apiVersion);
         $payload = $resource->jsonSerialize();
-        $headers = $this->composerHttpHeaders($unzerObj);
+        $headers = $this->composeHttpHeaders($unzerObj);
         $this->initRequest($url, $payload, $httpMethod, $headers);
         $httpAdapter  = $this->getAdapter();
         $response     = $httpAdapter->execute();
@@ -266,7 +266,7 @@ class HttpService
      *
      * @return array
      */
-    public function composerHttpHeaders(Unzer $unzer): array
+    public function composeHttpHeaders(Unzer $unzer): array
     {
         $locale      = $unzer->getLocale();
         $clientIp    = $unzer->getClientIp();

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -149,7 +149,7 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
     }
 
     /**
-     * Returns the set customer locale.
+     * Returns the set customer locale. This will be set as a request header field.
      *
      * @return string|null The locale of the customer.
      *                     Refer to the documentation under https://docs.unzer.com for a list of supported values.
@@ -186,6 +186,8 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
     }
 
     /**
+     * Sets the clientIp. This will be set as a request header field.
+     *
      * @param string|null $clientIp
      *
      * @return Unzer

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -68,10 +68,10 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
     /** @var string $key */
     private $key;
 
-    /** @var string $locale */
+    /** @var string|null $locale */
     private $locale;
 
-    /** @var string $clientIp */
+    /** @var string|null $clientIp */
     private $clientIp;
 
     /** @var ResourceServiceInterface $resourceService */
@@ -178,7 +178,7 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getClientIp(): ?string
     {

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -71,6 +71,9 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
     /** @var string $locale */
     private $locale;
 
+    /** @var string $clientIp */
+    private $clientIp;
+
     /** @var ResourceServiceInterface $resourceService */
     private $resourceService;
 
@@ -171,6 +174,25 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
         }
 
         $this->locale = str_replace('_', '-', $locale);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientIp(): ?string
+    {
+        return $this->clientIp;
+    }
+
+    /**
+     * @param string|null $clientIp
+     *
+     * @return Unzer
+     */
+    public function setClientIp($clientIp): Unzer
+    {
+        $this->clientIp = $clientIp;
         return $this;
     }
 

--- a/test/integration/CustomerTest.php
+++ b/test/integration/CustomerTest.php
@@ -423,5 +423,21 @@ class CustomerTest extends BaseIntegrationTest
         $this->assertEquals($customer->expose(), $fetchedCustomer->expose());
     }
 
+    /**
+     * Customer should contain clientIp set via header.
+     *
+     * @test
+     */
+    public function customerShouldContainClientIpSetViaHeader()
+    {
+        $customer = $this->getMinimalCustomer();
+        $clientIp = '123.123.123.123';
+        $this->unzer->setClientIp($clientIp);
+        $this->unzer->createCustomer($customer);
+
+        $fetchedCustomer = $this->unzer->fetchCustomer($customer->getId());
+        $this->assertEquals($clientIp, $fetchedCustomer->getGeoLocation()->getClientIp());
+    }
+
     //</editor-fold>
 }

--- a/test/integration/PaymentTypes/InvoiceSecuredTest.php
+++ b/test/integration/PaymentTypes/InvoiceSecuredTest.php
@@ -121,7 +121,6 @@ class InvoiceSecuredTest extends BaseIntegrationTest
         $this->unzer->setClientIp(null); // Ensure that the invalid ip is only used for type creation.
         $this->assertEquals($clientIp, $invoiceSecured->getGeoLocation()->getClientIp());
 
-
         $customer = $this->getMaximumCustomer();
         $customer->setShippingAddress($customer->getBillingAddress());
         $basket = $this->createBasket();

--- a/test/integration/PaymentTypes/InvoiceSecuredTest.php
+++ b/test/integration/PaymentTypes/InvoiceSecuredTest.php
@@ -113,11 +113,14 @@ class InvoiceSecuredTest extends BaseIntegrationTest
      */
     public function invoiceSecuredRequiresValidClientIpForCharge(): void
     {
-        $this->unzer->setClientIp('123.456.789.123');
+        $clientIp = '123.456.789.123';
+        $this->unzer->setClientIp($clientIp);
 
         /** @var InvoiceSecured $invoiceSecured */
         $invoiceSecured = $this->unzer->createPaymentType(new InvoiceSecured());
         $this->unzer->setClientIp(null); // Ensure that the invalid ip is only used for type creation.
+        $this->assertEquals($clientIp, $invoiceSecured->getGeoLocation()->getClientIp());
+
 
         $customer = $this->getMaximumCustomer();
         $customer->setShippingAddress($customer->getBillingAddress());
@@ -127,6 +130,21 @@ class InvoiceSecuredTest extends BaseIntegrationTest
         $this->expectExceptionCode(ApiResponseCodes::CORE_INVALID_IP_NUMBER);
 
         $invoiceSecured->charge(119.0, 'EUR', self::RETURN_URL, $customer, $basket->getOrderId(), null, $basket);
+    }
+
+    /**
+     * Verify creating a payment type with client ip header set, will overwrite the clientIp of the API resource.
+     *
+     * @test
+     */
+    public function verifySettingClientIpViaHeaderWillOverwriteClientIpOfTypeResource(): void
+    {
+        $clientIp = 'xxx.xxx.xxx.xxx';
+        $this->unzer->setClientIp($clientIp);
+
+        /** @var InvoiceSecured $invoiceSecured */
+        $invoiceSecured = $this->unzer->createPaymentType(new InvoiceSecured());
+        $this->assertEquals($clientIp, $invoiceSecured->getGeoLocation()->getClientIp());
     }
 
     /**

--- a/test/integration/PaymentTypes/InvoiceSecuredTest.php
+++ b/test/integration/PaymentTypes/InvoiceSecuredTest.php
@@ -107,6 +107,29 @@ class InvoiceSecuredTest extends BaseIntegrationTest
     }
 
     /**
+     * Verify charge with Invoice Secured throws an error when invalid ip is set.
+     *
+     * @test
+     */
+    public function invoiceSecuredRequiresValidClientIpForCharge(): void
+    {
+        $this->unzer->setClientIp('123.456.789.123');
+
+        /** @var InvoiceSecured $invoiceSecured */
+        $invoiceSecured = $this->unzer->createPaymentType(new InvoiceSecured());
+        $this->unzer->setClientIp(null); // Ensure that the invalid ip is only used for type creation.
+
+        $customer = $this->getMaximumCustomer();
+        $customer->setShippingAddress($customer->getBillingAddress());
+        $basket = $this->createBasket();
+
+        $this->expectException(UnzerApiException::class);
+        $this->expectExceptionCode(ApiResponseCodes::CORE_INVALID_IP_NUMBER);
+
+        $invoiceSecured->charge(119.0, 'EUR', self::RETURN_URL, $customer, $basket->getOrderId(), null, $basket);
+    }
+
+    /**
      * Verify Invoice Secured is chargeable.
      *
      * @test

--- a/test/integration/PaymentTypes/PaylaterInvoiceTest.php
+++ b/test/integration/PaymentTypes/PaylaterInvoiceTest.php
@@ -52,4 +52,21 @@ class PaylaterInvoiceTest extends BaseIntegrationTest
 
         return $invoice;
     }
+
+    /**
+     * Customer should contain clientIp set via header.
+     *
+     * @test
+     */
+    public function clientIpCanBeManuallySetForPaylaterInvoiceType()
+    {
+        $clientIp = '123.123.123.123';
+        $this->unzer->setClientIp($clientIp);
+
+        /** @var PaylaterInvoice $invoice */
+        $invoice = $this->unzer->createPaymentType(new PaylaterInvoice());
+        $fetchedInvoice = $this->unzer->fetchPaymentType($invoice->getId());
+
+        $this->assertEquals($clientIp, $fetchedInvoice->getGeoLocation()->getClientIp());
+    }
 }

--- a/test/integration/PaymentTypes/SofortTest.php
+++ b/test/integration/PaymentTypes/SofortTest.php
@@ -52,6 +52,7 @@ class SofortTest extends BaseIntegrationTest
         $fetchedSofort = $this->unzer->fetchPaymentType($sofort->getId());
         $this->assertInstanceOf(Sofort::class, $fetchedSofort);
         $this->assertEquals($sofort->expose(), $fetchedSofort->expose());
+        $this->assertNotEmpty($fetchedSofort->getGeoLocation()->getClientIp());
 
         return $fetchedSofort;
     }

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -173,18 +173,21 @@ class HttpServiceTest extends BasePaymentTest
      * Verify 'CLIENTIP' header only set when a clientIp is defined in the Unzer object.
      *
      * @test
-     * @dataProvider clientIPHeaderShouldOnlyBeSetIfPropertyIsNotEmptyDP
+     * @dataProvider clientIpHeaderShouldBeSetProperlyDP
      *
      * @param $clientIp
      * @param mixed $isHeaderExpected
      */
-    public function clientIpHeaderShouldNotExistIfPropertyIsNotSet($clientIp, $isHeaderExpected): void
+    public function clientIpHeaderShouldBeSetProperly($clientIp, $isHeaderExpected): void
     {
         $unzer = new Unzer('s-priv-MyTestKey', $clientIp);
         $unzer->setClientIp($clientIp);
 
-        $composerHttpHeaders = $unzer->getHttpService()->composerHttpHeaders($unzer);
+        $composerHttpHeaders = $unzer->getHttpService()->composeHttpHeaders($unzer);
         $this->assertEquals($isHeaderExpected, isset($composerHttpHeaders['CLIENTIP']));
+        if ($isHeaderExpected) {
+            $this->assertEquals($clientIp, $composerHttpHeaders['CLIENTIP']);
+        }
     }
 
     /**
@@ -461,7 +464,7 @@ class HttpServiceTest extends BasePaymentTest
     /**
      * Returns test data for method public function languageShouldOnlyBeSetIfSpecificallyDefined.
      */
-    public function clientIPHeaderShouldOnlyBeSetIfPropertyIsNotEmptyDP(): array
+    public function clientIpHeaderShouldBeSetProperlyDP(): array
     {
         return [
             'valid ipv4' => ['111.222.333.444', true],

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -176,29 +176,15 @@ class HttpServiceTest extends BasePaymentTest
      * @dataProvider clientIPHeaderShouldOnlyBeSetIfPropertyIsNotEmptyDP
      *
      * @param $clientIp
+     * @param mixed $isHeaderExpected
      */
-    public function clientIPHeaderShouldOnlyBeSetIfPropertyIsNotEmpty($clientIp): void
+    public function clientIpHeaderShouldNotExistIfPropertyIsNotSet($clientIp, $isHeaderExpected): void
     {
-        $httpServiceMock = $this->getMockBuilder(HttpService::class)->setMethods(['getAdapter'])->getMock();
-        $adapterMock = $this->getMockBuilder(CurlAdapter::class)->setMethods(['setHeaders', 'execute'])->getMock();
-        $httpServiceMock->method('getAdapter')->willReturn($adapterMock);
-
         $unzer = new Unzer('s-priv-MyTestKey', $clientIp);
         $unzer->setClientIp($clientIp);
-        $resource = (new DummyResource())->setParentResource($unzer);
 
-        /** @noinspection PhpParamsInspection */
-        $adapterMock->expects($this->once())->method('setHeaders')->with(
-            $this->callback(
-                static function ($headers) use ($clientIp) {
-                    return $clientIp === ($headers['CLIENTIP'] ?? null);
-                }
-            )
-        );
-        $adapterMock->method('execute')->willReturn('myResponseString');
-
-        /** @var HttpService $httpServiceMock*/
-        $httpServiceMock->send('/my/uri/123', $resource);
+        $composerHttpHeaders = $unzer->getHttpService()->composerHttpHeaders($unzer);
+        $this->assertEquals($isHeaderExpected, isset($composerHttpHeaders['CLIENTIP']));
     }
 
     /**
@@ -478,10 +464,11 @@ class HttpServiceTest extends BasePaymentTest
     public function clientIPHeaderShouldOnlyBeSetIfPropertyIsNotEmptyDP(): array
     {
         return [
-            'valid ipv4' => ['111.222.333.444'],
-            'valid ipv6' => ['684D:1111:222:3333:4444:5555:6:7'],
-            'valid ipv6 (dual)' => ['2001:db8:3333:4444:5555:6666:1.2.3.4'],
-            'null' => [null]
+            'valid ipv4' => ['111.222.333.444', true],
+            'valid ipv6' => ['684D:1111:222:3333:4444:5555:6:7', true],
+            'valid ipv6 (dual)' => ['2001:db8:3333:4444:5555:6666:1.2.3.4', true],
+            'empty string' => ['', false],
+            'null' => [null, false]
         ];
     }
 

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -180,13 +180,13 @@ class HttpServiceTest extends BasePaymentTest
      */
     public function clientIpHeaderShouldBeSetProperly($clientIp, $isHeaderExpected): void
     {
-        $unzer = new Unzer('s-priv-MyTestKey', $clientIp);
+        $unzer = new Unzer('s-priv-MyTestKey');
         $unzer->setClientIp($clientIp);
 
-        $composerHttpHeaders = $unzer->getHttpService()->composeHttpHeaders($unzer);
-        $this->assertEquals($isHeaderExpected, isset($composerHttpHeaders['CLIENTIP']));
+        $composeHttpHeaders = $unzer->getHttpService()->composeHttpHeaders($unzer);
+        $this->assertEquals($isHeaderExpected, isset($composeHttpHeaders['CLIENTIP']));
         if ($isHeaderExpected) {
-            $this->assertEquals($clientIp, $composerHttpHeaders['CLIENTIP']);
+            $this->assertEquals($clientIp, $composeHttpHeaders['CLIENTIP']);
         }
     }
 

--- a/test/unit/UnzerTest.php
+++ b/test/unit/UnzerTest.php
@@ -82,7 +82,9 @@ class UnzerTest extends BasePaymentTest
     {
         $unzer = new Unzer('s-priv-1234');
         $unzer->setLocale('myLocale');
+        $unzer->setClientIp('myIpAddress');
         $this->assertEquals('myLocale', $unzer->getLocale());
+        $this->assertEquals('myIpAddress', $unzer->getClientIp());
 
         try {
             $unzer->setKey('this is not a valid key');


### PR DESCRIPTION
- Add clientIp property to unzer facade, which will be set as  header field for requests.
- Includes integration test with invalid ip address for invoice secured.
- Add geolocation trait to abstraact payment type class, since the geolocation exists for every payment type resource.