### PR TITLE
Umcs 479/extend authorization account properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Remove redundant `currency` parameter from `Unzer::chargePayment()` method.
 * Add "geoLocation" property to all payment type classes.
 * Several minor improvements.
+* Add account information coming from PAPI to Authorize class.
 
 ## [1.1.5.0](https://github.com/unzerdev/php-sdk/compare/1.1.4.2..1.1.5.0)
 ### Added

--- a/examples/PaylaterInvoice/Controller.php
+++ b/examples/PaylaterInvoice/Controller.php
@@ -92,7 +92,7 @@ try {
     $_SESSION['ShortId'] = $transaction->getShortId();
     $_SESSION['PaymentId'] = $transaction->getPaymentId();
     $_SESSION['isAuthorizeTransaction'] = true;
-/*    $_SESSION['additionalPaymentInformation'] =
+    $_SESSION['additionalPaymentInformation'] =
         sprintf(
             "Please transfer the amount of %f %s to the following account:<br /><br />"
             . "Holder: %s<br/>"
@@ -106,7 +106,7 @@ try {
             $transaction->getIban(),
             $transaction->getBic(),
             $transaction->getDescriptor()
-        );*/
+        );
 
     // To avoid redundant code this example redirects to the general ReturnController which contains the code example to handle payment results.
     redirect(RETURN_CONTROLLER_URL);

--- a/src/Resources/TransactionTypes/Authorization.php
+++ b/src/Resources/TransactionTypes/Authorization.php
@@ -27,6 +27,7 @@ namespace UnzerSDK\Resources\TransactionTypes;
 use UnzerSDK\Adapter\HttpAdapterInterface;
 use UnzerSDK\Exceptions\UnzerApiException;
 use UnzerSDK\Resources\Payment;
+use UnzerSDK\Traits\HasAccountInformation;
 use UnzerSDK\Traits\HasCancellations;
 use UnzerSDK\Traits\HasInvoiceId;
 use UnzerSDK\Traits\HasRecurrenceType;
@@ -37,6 +38,7 @@ class Authorization extends AbstractTransactionType
     use HasCancellations;
     use HasInvoiceId;
     use HasRecurrenceType;
+    use HasAccountInformation;
 
     /** @var float $amount */
     protected $amount = 0.0;

--- a/src/Resources/TransactionTypes/Charge.php
+++ b/src/Resources/TransactionTypes/Charge.php
@@ -26,6 +26,7 @@ namespace UnzerSDK\Resources\TransactionTypes;
 
 use UnzerSDK\Adapter\HttpAdapterInterface;
 use UnzerSDK\Exceptions\UnzerApiException;
+use UnzerSDK\Traits\HasAccountInformation;
 use UnzerSDK\Traits\HasCancellations;
 use UnzerSDK\Traits\HasInvoiceId;
 use UnzerSDK\Traits\HasRecurrenceType;
@@ -36,6 +37,7 @@ class Charge extends AbstractTransactionType
     use HasCancellations;
     use HasInvoiceId;
     use HasRecurrenceType;
+    use HasAccountInformation;
 
     /** @var float $amount */
     protected $amount;
@@ -45,18 +47,6 @@ class Charge extends AbstractTransactionType
 
     /** @var string $returnUrl */
     protected $returnUrl;
-
-    /** @var string $iban */
-    private $iban;
-
-    /** @var string bic */
-    private $bic;
-
-    /** @var string $holder */
-    private $holder;
-
-    /** @var string $descriptor */
-    private $descriptor;
 
     /** @var string $paymentReference */
     protected $paymentReference;
@@ -158,94 +148,6 @@ class Charge extends AbstractTransactionType
     public function setReturnUrl($returnUrl): self
     {
         $this->returnUrl = $returnUrl;
-        return $this;
-    }
-
-    /**
-     * Returns the IBAN of the account the customer needs to transfer the amount to.
-     * E. g. invoice, prepayment, etc.
-     *
-     * @return string|null
-     */
-    public function getIban(): ?string
-    {
-        return $this->iban;
-    }
-
-    /**
-     * @param string $iban
-     *
-     * @return self
-     */
-    protected function setIban(string $iban): self
-    {
-        $this->iban = $iban;
-        return $this;
-    }
-
-    /**
-     * Returns the BIC of the account the customer needs to transfer the amount to.
-     * E. g. invoice, prepayment, etc.
-     *
-     * @return string|null
-     */
-    public function getBic(): ?string
-    {
-        return $this->bic;
-    }
-
-    /**
-     * @param string $bic
-     *
-     * @return self
-     */
-    protected function setBic(string $bic): self
-    {
-        $this->bic = $bic;
-        return $this;
-    }
-
-    /**
-     * Returns the holder of the account the customer needs to transfer the amount to.
-     * E. g. invoice, prepayment, etc.
-     *
-     * @return string|null
-     */
-    public function getHolder(): ?string
-    {
-        return $this->holder;
-    }
-
-    /**
-     * @param string $holder
-     *
-     * @return self
-     */
-    protected function setHolder(string $holder): self
-    {
-        $this->holder = $holder;
-        return $this;
-    }
-
-    /**
-     * Returns the Descriptor the customer needs to use when transferring the amount.
-     * E. g. invoice, prepayment, etc.
-     *
-     * @return string|null
-     */
-    public function getDescriptor(): ?string
-    {
-        return $this->descriptor;
-    }
-
-    /**
-     * @param string $descriptor
-     *
-     * @return self
-     */
-    protected function setDescriptor(string $descriptor): self
-    {
-        $this->descriptor = $descriptor;
         return $this;
     }
 

--- a/src/Traits/HasAccountInformation.php
+++ b/src/Traits/HasAccountInformation.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ *  Trait containing a property set of transaction regarding bank account information.
+ *
+ *  Copyright (C) 2022 - today Unzer E-Com GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @link  https://docs.unzer.com/
+ *
+ *  @author  David Owusu <development@unzer.com>
+ *
+ *  @package  UnzerSDK
+ *
+ */
+
+namespace UnzerSDK\Traits;
+
+trait HasAccountInformation
+{
+    /** @var string $iban */
+    private $iban;
+
+    /** @var string bic */
+    private $bic;
+
+    /** @var string $holder */
+    private $holder;
+
+    /** @var string $descriptor */
+    private $descriptor;
+
+    /**
+     * Returns the IBAN of the account the customer needs to transfer the amount to.
+     * E. g. invoice, prepayment, etc.
+     *
+     * @return string|null
+     */
+    public function getIban(): ?string
+    {
+        return $this->iban;
+    }
+
+    /**
+     * @param string $iban
+     *
+     * @return self
+     */
+    protected function setIban(string $iban): self
+    {
+        $this->iban = $iban;
+        return $this;
+    }
+
+    /**
+     * Returns the BIC of the account the customer needs to transfer the amount to.
+     * E. g. invoice, prepayment, etc.
+     *
+     * @return string|null
+     */
+    public function getBic(): ?string
+    {
+        return $this->bic;
+    }
+
+    /**
+     * @param string $bic
+     *
+     * @return self
+     */
+    protected function setBic(string $bic): self
+    {
+        $this->bic = $bic;
+        return $this;
+    }
+
+    /**
+     * Returns the holder of the account the customer needs to transfer the amount to.
+     * E. g. invoice, prepayment, etc.
+     *
+     * @return string|null
+     */
+    public function getHolder(): ?string
+    {
+        return $this->holder;
+    }
+
+    /**
+     * @param string $holder
+     *
+     * @return self
+     */
+    protected function setHolder(string $holder): self
+    {
+        $this->holder = $holder;
+        return $this;
+    }
+
+    /**
+     * Returns the Descriptor the customer needs to use when transferring the amount.
+     * E. g. invoice, prepayment, etc.
+     *
+     * @return string|null
+     */
+    public function getDescriptor(): ?string
+    {
+        return $this->descriptor;
+    }
+
+    /**
+     * @param string $descriptor
+     *
+     * @return self
+     */
+    protected function setDescriptor(string $descriptor): self
+    {
+        $this->descriptor = $descriptor;
+        return $this;
+    }
+}


### PR DESCRIPTION
Moved `iban`, `bic`, `holder`, `descriptor` properties from `Charge` class to a trait and use it in `Charge` and `Authorization` class