### PR TITLE
Update automatic test due to changed behaviour of Payment API.

### DIFF
--- a/test/BaseIntegrationTest.php
+++ b/test/BaseIntegrationTest.php
@@ -57,7 +57,8 @@ class BaseIntegrationTest extends BasePaymentTest
         }
     }
 
-    /**
+    /** Creates a Paylater Invoice authorization transaction with an amount of 99.99€.
+     *
      * @return Authorization
      *
      * @throws \UnzerSDK\Exceptions\UnzerApiException

--- a/test/integration/PaymentTypes/CardTest.php
+++ b/test/integration/PaymentTypes/CardTest.php
@@ -607,11 +607,11 @@ class CardTest extends BaseIntegrationTest
     {
         $cardDetailsA = new CardDetails();
         $cardDetailsAObj          = (object)[
-            'cardType'          => 'CLASSIC',
-            'account'           => 'CREDIT',
-            'countryIsoA2'      => 'RU',
-            'countryName'       => 'RUSSIAN FEDERATION',
-            'issuerName'        => '',
+            'cardType'          => 'STANDARD',
+            'account'           => 'DEBIT',
+            'countryIsoA2'      => 'BE',
+            'countryName'       => 'BELGIUM',
+            'issuerName'        => 'MASTERCARD EUROPE',
             'issuerUrl'         => '',
             'issuerPhoneNumber' => ''
         ];
@@ -630,7 +630,7 @@ class CardTest extends BaseIntegrationTest
         $cardDetailsB->handleResponse($cardDetailsBObj);
 
         return [
-            'card type set'   => ['4012001037461114', $cardDetailsA],
+            'card type set'   => ['6799851000000032', $cardDetailsA],
             'issuer data set' => ['5453010000059543', $cardDetailsB]
         ];
     }

--- a/test/integration/TransactionTypes/PaylaterCancelTest.php
+++ b/test/integration/TransactionTypes/PaylaterCancelTest.php
@@ -98,16 +98,13 @@ class PaylaterCancelTest extends BaseIntegrationTest
     /**
      * @test
      */
-    public function verifyPartReversalAttemptWillCancelFullAmount(): void
+    public function verifyPartReversalAttemptWillRaiseApiException(): void
     {
         $authorization = $this->createPaylaterAuthorization();
         $reversalAmount = 33.33;
-        $cancel = $this->unzer->cancelAuthorizedPayment($authorization->getPayment(), new Cancellation($reversalAmount));
+        $this->expectException(UnzerApiException::class);
 
-        $this->assertTrue($cancel->isSuccess());
-        $this->assertEquals(99.99, $cancel->getAmount());
-        $this->assertCount(0, $authorization->getCancellations());
-        $this->assertCount(1, $authorization->getPayment()->getCancellations());
+        $this->unzer->cancelAuthorizedPayment($authorization->getPayment(), new Cancellation($reversalAmount));
     }
 
     /**


### PR DESCRIPTION
- Updated tests due to changed Payment API behaviour:
  - API returns error in case of partly reversal of a paylater invoice payment.
  - A testing card is blacklisted and got replaced with another one.