### PR TITLE
UMCS-172(refactor) move backwards compatibility test for hire purchas…

### DIFF
--- a/test/integration/PaymentTypes/HirePurchaseTest.php
+++ b/test/integration/PaymentTypes/HirePurchaseTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+/** @noinspection PhpDocMissingThrowsInspection */
+/**
+ * This class defines integration tests to verify backwards compatibility with deprecated hire-purchase-direct-debit resource.
+ *
+ * Copyright (C) 2020 - today Unzer E-Com GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @link  https://docs.unzer.com/
+ *
+ * @package  UnzerSDK\test\integration\PaymentTypes
+ */
+namespace UnzerSDK\test\integration\PaymentTypes;
+
+use UnzerSDK\Exceptions\UnzerApiException;
+use UnzerSDK\Resources\AbstractUnzerResource;
+use UnzerSDK\Resources\PaymentTypes\InstallmentSecured;
+use UnzerSDK\Resources\TransactionTypes\Charge;
+use UnzerSDK\test\BaseIntegrationTest;
+use function count;
+
+class HirePurchaseTest extends BaseIntegrationTest
+{
+    /**
+     * Verify, backwards compatibility regarding fetching payment type and map it to invoice secured class.
+     *
+     * @test
+     */
+    public function hddTypeShouldBeFetchable(): InstallmentSecured
+    {
+        // Mock a hdd Type
+        $date = $this->getTodaysDateString();
+        $requestData =
+            [
+                "iban" =>"DE89370400440532013000",
+                "bic" => "COBADEFFXXX",
+                "accountHolder" => "Max Mustermann",
+                "invoiceDueDate" => $date,
+                "numberOfRates" => 3,
+                "invoiceDate" => $date,
+                "dayOfPurchase" => $date,
+                "orderDate" => $date,
+                "totalPurchaseAmount" => 119,
+                "totalInterestAmount" => 0.96,
+                "totalAmount" => 119.96,
+                "effectiveInterestRate" => 4.99,
+                "nominalInterestRate" => 4.92,
+                "feeFirstRate" => 0,
+                "feePerRate" => 0,
+                "monthlyRate" => 39.99,
+                "lastRate" => 39.98,
+        ];
+
+        $payload = json_encode($requestData);
+        $hddMock = $this->getMockBuilder(InstallmentSecured::class)
+            ->setMethods(['getUri', 'jsonSerialize'])
+            ->getMock();
+        $hddMock->method('getUri')->willReturn('/types/hire-purchase-direct-debit');
+        $hddMock->method('jsonSerialize')->willReturn($payload);
+
+        // When
+        /** @var InstallmentSecured $hddMock */
+        $this->unzer->createPaymentType($hddMock);
+        $this->assertRegExp('/^s-hdd-[.]*/', $hddMock->getId());
+
+        // Then
+        $fetchedType = $this->unzer->fetchPaymentType($hddMock->getId());
+        $this->assertInstanceOf(InstallmentSecured::class, $fetchedType);
+        $this->assertRegExp('/^s-hdd-[.]*/', $fetchedType->getId());
+
+        return $fetchedType;
+    }
+
+    /**
+     * Verify fetched hdd type can be authorized and charged
+     *
+     * @test
+     * @depends hddTypeShouldBeFetchable
+     *
+     * @param InstallmentSecured $hddType fetched hdd type.
+     *
+     * @return AbstractUnzerResource|Charge
+     *
+     * @throws UnzerApiException
+     */
+    public function hddTypeAuthorizeAndCharge(InstallmentSecured $hddType)
+    {
+        $customer = $this->getMaximumCustomer();
+        $basket = $this->createBasket();
+
+        $auth = $hddType->authorize(119.00, 'EUR', 'https://unzer.com', $customer, null, null, $basket);
+        $charge = $auth->getPayment()->charge();
+        $this->assertNotNull($auth);
+        $this->assertNotEmpty($auth->getId());
+        $this->assertTrue($auth->isSuccess());
+
+        return $charge;
+    }
+
+    /**
+     * Verify fetched hdd payment can be shipped.
+     *
+     * @test
+     * @depends hddTypeAuthorizeAndCharge
+     */
+    public function hddTypeShouldBeShippable(Charge $hddCharge)
+    {
+        $invoiceId = 'i' . self::generateRandomId();
+        $ship = $this->unzer->ship($hddCharge->getPayment(), $invoiceId);
+
+        $this->assertNotNull($ship);
+        return $hddCharge;
+    }
+
+    /**
+     * Verify full cancel of charged HP after shipment.
+     *
+     * @test
+     * @depends hddTypeAuthorizeAndCharge
+     */
+    public function hddChargeCanBePartiallyCancledBeforeShipment(Charge $hddCharge): void
+    {
+        $payment = $hddCharge->getPayment();
+
+        $cancel1 = $payment->cancelAmount(66, null, null, 60, 6);
+        $cancel2 = $payment->cancelAmount(43, null, null, 40, 3);
+        $this->assertGreaterThan(0, count($cancel1));
+        $this->assertGreaterThan(0, count($cancel2));
+    }
+}

--- a/test/integration/PaymentTypes/InstallmentSecuredTest.php
+++ b/test/integration/PaymentTypes/InstallmentSecuredTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpUnhandledExceptionInspection */
 /** @noinspection PhpDocMissingThrowsInspection */
 /**
@@ -27,7 +28,6 @@ namespace UnzerSDK\test\integration\PaymentTypes;
 
 use UnzerSDK\Constants\ApiResponseCodes;
 use UnzerSDK\Exceptions\UnzerApiException;
-use UnzerSDK\Resources\AbstractUnzerResource;
 use UnzerSDK\Resources\Customer;
 use UnzerSDK\Resources\CustomerFactory;
 use UnzerSDK\Resources\EmbeddedResources\Address;
@@ -43,9 +43,9 @@ class InstallmentSecuredTest extends BaseIntegrationTest
      * Verify the following features:
      * 1. fetching instalment plans.
      * 2. selecting plan
-     * 3. create hp resource
-     * 4. fetch hp resource
-     * 5 test update hp resource
+     * 3. create ins resource
+     * 4. fetch ins resource
+     * 5 test update ins resource
      *
      * @test
      */
@@ -72,96 +72,6 @@ class InstallmentSecuredTest extends BaseIntegrationTest
         $insClone = clone $ins;
         $this->unzer->updatePaymentType($ins);
         $this->assertEquals($insClone->expose(), $ins->expose());
-    }
-
-    /**
-     * Verify, backwards compatibility regarding fetching payment type and map it to invoice secured class.
-     *
-     * @test
-     */
-    public function hddTypeShouldBeFetchable(): InstallmentSecured
-    {
-        // Mock a hdd Type
-        $date = $this->getTodaysDateString();
-        $requestData =
-            [
-                "iban" =>"DE89370400440532013000",
-                "bic" => "COBADEFFXXX",
-                "accountHolder" => "Max Mustermann",
-                "invoiceDueDate" => $date,
-                "numberOfRates" => 3,
-                "invoiceDate" => $date,
-                "dayOfPurchase" => $date,
-                "orderDate" => $date,
-                "totalPurchaseAmount" => 119,
-                "totalInterestAmount" => 0.96,
-                "totalAmount" => 119.96,
-                "effectiveInterestRate" => 4.99,
-                "nominalInterestRate" => 4.92,
-                "feeFirstRate" => 0,
-                "feePerRate" => 0,
-                "monthlyRate" => 39.99,
-                "lastRate" => 39.98,
-        ];
-
-        $payload = json_encode($requestData);
-        $hddMock = $this->getMockBuilder(InstallmentSecured::class)
-            ->setMethods(['getUri', 'jsonSerialize'])
-            ->getMock();
-        $hddMock->method('getUri')->willReturn('/types/hire-purchase-direct-debit');
-        $hddMock->method('jsonSerialize')->willReturn($payload);
-
-        // When
-        /** @var InstallmentSecured $insType */
-        $this->unzer->createPaymentType($hddMock);
-        $this->assertRegExp('/^s-hdd-[.]*/', $hddMock->getId());
-
-        // Then
-        $fetchedType = $this->unzer->fetchPaymentType($hddMock->getId());
-        $this->assertInstanceOf(InstallmentSecured::class, $fetchedType);
-        $this->assertRegExp('/^s-hdd-[.]*/', $fetchedType->getId());
-
-        return $fetchedType;
-    }
-
-    /**
-     * Verify fetched hdd type can be authorized and charged
-     *
-     * @test
-     * @depends hddTypeShouldBeFetchable
-     *
-     * @param InstallmentSecured $hddType fetched ins type.
-     *
-     * @return AbstractUnzerResource|Charge
-     *
-     * @throws UnzerApiException
-     */
-    public function hddTypeAuthorizeAndCharge(InstallmentSecured $hddType)
-    {
-        $customer = $this->getMaximumCustomer();
-        $basket = $this->createBasket();
-
-        $auth = $hddType->authorize(119.00, 'EUR', 'https://unzer.com', $customer, null, null, $basket);
-        $charge = $auth->getPayment()->charge();
-        $this->assertNotNull($auth);
-        $this->assertNotEmpty($auth->getId());
-        $this->assertTrue($auth->isSuccess());
-
-        return $charge;
-    }
-
-    /**
-     * Verify fetched hdd payment can be shipped.
-     *
-     * @test
-     * @depends hddTypeAuthorizeAndCharge
-     */
-    public function insTypeShouldBeShippable(Charge $hddCharge)
-    {
-        $invoiceId = 'i' . self::generateRandomId();
-        $ship = $this->unzer->ship($hddCharge->getPayment(), $invoiceId);
-
-        $this->assertNotNull($ship);
     }
 
     /**
@@ -273,8 +183,6 @@ class InstallmentSecuredTest extends BaseIntegrationTest
      * Verify full cancel of charged HP.
      *
      * @test
-     *
-     * @depends verifyChargingAnInitializedInstallmentSecured
      */
     public function verifyChargeAndFullCancelAnInitializedInstallmentSecured(): void
     {
@@ -298,8 +206,6 @@ class InstallmentSecuredTest extends BaseIntegrationTest
      * Verify full cancel of charged HP.
      *
      * @test
-     *
-     * @depends verifyChargingAnInitializedInstallmentSecured
      */
     public function verifyPartlyCancelChargedInstallmentSecured(): void
     {
@@ -324,8 +230,6 @@ class InstallmentSecuredTest extends BaseIntegrationTest
      * Verify full cancel of charged HP after shipment.
      *
      * @test
-     *
-     * @depends verifyChargingAnInitializedInstallmentSecured
      */
     public function verifyChargeAndFullCancelAnInitializedInstallmentSecuredAfterShipment(): void
     {
@@ -341,9 +245,9 @@ class InstallmentSecuredTest extends BaseIntegrationTest
         $authorize = $ins->authorize(119.0, 'EUR', self::RETURN_URL, $this->getCustomer(), null, null, $basket = $this->createBasket());
         $payment = $authorize->getPayment();
 
-        $hddCharge = $payment->charge();
+        $charge = $payment->charge();
         $invoiceId = 'i' . self::generateRandomId();
-        $ship = $this->unzer->ship($hddCharge->getPayment(), $invoiceId);
+        $ship = $this->unzer->ship($charge->getPayment(), $invoiceId);
         $this->assertNotNull($ship);
 
         $cancel = $payment->cancelAmount();
@@ -354,8 +258,6 @@ class InstallmentSecuredTest extends BaseIntegrationTest
      * Verify full cancel of charged HP after shipment.
      *
      * @test
-     *
-     * @depends verifyChargingAnInitializedInstallmentSecured
      */
     public function verifyPartlyCancelChargedInstallmentSecuredAfterShipment(): void
     {
@@ -371,9 +273,9 @@ class InstallmentSecuredTest extends BaseIntegrationTest
         $authorize = $ins->authorize(119.0, 'EUR', self::RETURN_URL, $this->getCustomer(), null, null, $basket = $this->createBasket());
         $payment = $authorize->getPayment();
 
-        $hddCharge = $payment->charge();
+        $charge = $payment->charge();
         $invoiceId = 'i' . self::generateRandomId();
-        $ship = $this->unzer->ship($hddCharge->getPayment(), $invoiceId);
+        $ship = $this->unzer->ship($charge->getPayment(), $invoiceId);
         $this->assertNotNull($ship);
 
         $cancel = $payment->cancelAmount(59.5, null, null, 50.0, 9.5);


### PR DESCRIPTION
- move backwards compatibility test for hire purchase into a separate test class for better distinguishing.