### PR TITLE
(UMCS-565) Automatic sbx switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres
 to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+*   Sandbox API-URL will automatically be used for API calls depending on the private key.
+
 ## [1.2.1.0](https://github.com/unzerdev/php-sdk/compare/1.2.0.0..1.2.1.0)
 
 ### Added

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -35,6 +35,7 @@ class HttpService
 {
     private const URL_PART_STAGING_ENVIRONMENT = 'stg';
     private const URL_PART_DEVELOPMENT_ENVIRONMENT = 'dev';
+    private const URL_PART_SANDBOX_ENVIRONMENT = 'sbx';
 
     /** @var HttpAdapterInterface $httpAdapter */
     private $httpAdapter;
@@ -120,10 +121,10 @@ class HttpService
         $unzerObj = $resource->getUnzerObject();
 
         // perform request
-        $url     = $this->getEnvironmentUrl($uri, $apiVersion);
+        $requestUrl = $this->buildRequestUrl($uri, $apiVersion, $unzerObj);
         $payload = $resource->jsonSerialize();
         $headers = $this->composeHttpHeaders($unzerObj);
-        $this->initRequest($url, $payload, $httpMethod, $headers);
+        $this->initRequest($requestUrl, $payload, $httpMethod, $headers);
         $httpAdapter  = $this->getAdapter();
         $response     = $httpAdapter->execute();
         $responseCode = $httpAdapter->getResponseCode();
@@ -133,7 +134,7 @@ class HttpService
         try {
             $this->handleErrors($responseCode, $response);
         } finally {
-            $this->debugLog($unzerObj, $payload, $headers, $responseCode, $httpMethod, $url, $response);
+            $this->debugLog($unzerObj, $payload, $headers, $responseCode, $httpMethod, $requestUrl, $response);
         }
 
         return $response;
@@ -242,21 +243,10 @@ class HttpService
      *
      * @return string
      */
-    private function getEnvironmentUrl($uri, string $apiVersion): string
+    private function buildRequestUrl($uri, string $apiVersion, Unzer $unzer): string
     {
-        $envUrl = [];
-        switch ($this->getEnvironmentService()->getPapiEnvironment()) {
-            case EnvironmentService::ENV_VAR_VALUE_STAGING_ENVIRONMENT:
-                $envUrl[] = self::URL_PART_STAGING_ENVIRONMENT;
-                break;
-            case EnvironmentService::ENV_VAR_VALUE_DEVELOPMENT_ENVIRONMENT:
-                $envUrl[] = self::URL_PART_DEVELOPMENT_ENVIRONMENT;
-                break;
-            default:
-                break;
-        }
-        $envUrl[] = Unzer::BASE_URL;
-        return 'https://' . implode('-', $envUrl) . '/' . $apiVersion . $uri;
+        $envPrefix = $this->getEnvironmentPrefix($unzer);
+        return "https://" . $envPrefix . Unzer::BASE_URL . "/" . $apiVersion . $uri;
     }
 
     /**
@@ -284,5 +274,31 @@ class HttpService
         }
 
         return $httpHeaders;
+    }
+
+    /** Determine the environment to be used for Api calls and returns the prefix for it. Production environment has no prefix.
+     *
+     * @param Unzer $unzer
+     *
+     * @return string
+     */
+    private function getEnvironmentPrefix(Unzer $unzer): string
+    {
+        // Production Environment uses no prefix.
+        if ($unzer->hasProductionKey()) {
+            return '';
+        }
+
+        switch ($this->getEnvironmentService()->getPapiEnvironment()) {
+            case EnvironmentService::ENV_VAR_VALUE_STAGING_ENVIRONMENT:
+                $envPrefix = self::URL_PART_STAGING_ENVIRONMENT;
+                break;
+            case EnvironmentService::ENV_VAR_VALUE_DEVELOPMENT_ENVIRONMENT:
+                $envPrefix = self::URL_PART_DEVELOPMENT_ENVIRONMENT;
+                break;
+            default:
+                $envPrefix = self::URL_PART_SANDBOX_ENVIRONMENT;
+        }
+        return $envPrefix . '-';
     }
 }

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -285,7 +285,7 @@ class HttpService
     private function getEnvironmentPrefix(Unzer $unzer): string
     {
         // Production Environment uses no prefix.
-        if ($unzer->hasProductionKey()) {
+        if ($this->isProductionKey($unzer->getKey())) {
             return '';
         }
 
@@ -300,5 +300,16 @@ class HttpService
                 $envPrefix = self::URL_PART_SANDBOX_ENVIRONMENT;
         }
         return $envPrefix . '-';
+    }
+
+    /** Determine whether key is for production environment.
+     *
+     * @param string $privateKey
+     *
+     * @return bool
+     */
+    private function isProductionKey(string $privateKey): bool
+    {
+        return strpos($privateKey, 'p') === 0;
     }
 }

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -136,6 +136,8 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
      * @return Unzer This Unzer object.
      *
      * @throws RuntimeException Throws a RuntimeException when the key is invalid.
+     *
+     * @deprecated public access will be removed. Please create a new instance with a different keypair instead.
      */
     public function setKey($key): Unzer
     {
@@ -1057,6 +1059,11 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
                 $debugHandler->log('(' . getmypid() . ') ' . $message);
             }
         }
+    }
+
+    public function hasProductionKey(): bool
+    {
+        return strpos($this->getKey(), 'p') === 0;
     }
 
     //</editor-fold>

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -1061,10 +1061,5 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
         }
     }
 
-    public function hasProductionKey(): bool
-    {
-        return strpos($this->getKey(), 'p') === 0;
-    }
-
     //</editor-fold>
 }

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -394,7 +394,7 @@ class HttpServiceTest extends BasePaymentTest
     }
 
     /**
-     * Verify environment switches when environment variable defines PAPI environment.
+     * Verify environment switches accordingly depending on environment variable and keypair defines PAPI environment.
      *
      * @test
      *
@@ -403,12 +403,12 @@ class HttpServiceTest extends BasePaymentTest
      * @param $environment
      * @param $apiUrl
      */
-    public function environmentUrlSwitchesWithEnvironmentVariable($environment, $apiUrl): void
+    public function environmentUrlSwitchesWithEnvironmentVariable($environment, $apiUrl, $key): void
     {
         $adapterMock = $this->getMockBuilder(CurlAdapter::class)->setMethods(['init', 'setUserAgent', 'setHeaders', 'execute', 'getResponseCode', 'close'])->getMock();
         /** @noinspection PhpParamsInspection */
         $adapterMock->expects($this->once())->method('init')->with($apiUrl, self::anything(), self::anything());
-        $resource = (new DummyResource())->setParentResource(new Unzer('s-priv-MyTestKey'));
+        $resource = (new DummyResource())->setParentResource(new Unzer($key));
         $adapterMock->method('execute')->willReturn('myResponseString');
         $adapterMock->method('getResponseCode')->willReturn('42');
 
@@ -478,12 +478,25 @@ class HttpServiceTest extends BasePaymentTest
      */
     public function environmentUrlSwitchesWithEnvironmentVariableDP(): array
     {
+        $devUrl = 'https://dev-api.unzer.com/v1';
+        $stgUrl = 'https://stg-api.unzer.com/v1';
+        $sbxUrl = 'https://sbx-api.unzer.com/v1';
+        $prodUrl = 'https://api.unzer.com/v1';
+
+        $prodKey = 'p-priv-MyTestKey';
+        $sbxKey = 's-priv-MyTestKey';
+
         return [
-            'Dev' => [EnvironmentService::ENV_VAR_VALUE_DEVELOPMENT_ENVIRONMENT, 'https://dev-api.unzer.com/v1'],
-            'Prod' => [EnvironmentService::ENV_VAR_VALUE_PROD_ENVIRONMENT, 'https://api.unzer.com/v1'],
-            'Stg' => [EnvironmentService::ENV_VAR_VALUE_STAGING_ENVIRONMENT, 'https://stg-api.unzer.com/v1'],
-            'else' => ['something else', 'https://api.unzer.com/v1'],
-            'undefined' => ['', 'https://api.unzer.com/v1']
+            'Dev with production key' => [EnvironmentService::ENV_VAR_VALUE_DEVELOPMENT_ENVIRONMENT, $prodUrl, $prodKey],
+            'Prod with production key' => [EnvironmentService::ENV_VAR_VALUE_PROD_ENVIRONMENT, $prodUrl, $prodKey],
+            'Stg with production key' => [EnvironmentService::ENV_VAR_VALUE_STAGING_ENVIRONMENT, $prodUrl, $prodKey],
+            'something else with production key' => ['something else', $prodUrl, $prodKey],
+            'undefined with production key' => ['', $prodUrl, $prodKey],
+            'Dev with sandbox key' => [EnvironmentService::ENV_VAR_VALUE_DEVELOPMENT_ENVIRONMENT, $devUrl, $sbxKey],
+            'Prod with sandbox key' => [EnvironmentService::ENV_VAR_VALUE_PROD_ENVIRONMENT, $sbxUrl, $sbxKey],
+            'Stg with sandbox key' => [EnvironmentService::ENV_VAR_VALUE_STAGING_ENVIRONMENT, $stgUrl, $sbxKey],
+            'something else with sandbox key' => ['something else', $sbxUrl, $sbxKey],
+            'undefined with sandbox key' => ['', $sbxUrl, $sbxKey],
         ];
     }
 

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -109,7 +109,7 @@ class HttpServiceTest extends BasePaymentTest
         $adapterMock->expects($this->once())->method('init')->with(
             $this->callback(
                 static function ($url) {
-                    return str_replace(['dev-api', 'stg-api'], 'api', $url) === 'https://api.unzer.com/v1/my/uri/123';
+                    return str_replace(['dev-api', 'stg-api'], 'sbx-api', $url) === 'https://sbx-api.unzer.com/v1/my/uri/123';
                 }
             ),
             '{"dummyResource": "JsonSerialized"}',
@@ -206,7 +206,7 @@ class HttpServiceTest extends BasePaymentTest
         $loggerMock->expects($this->exactly(7))->method('log')->withConsecutive(
             [ $this->callback(
                 static function ($string) {
-                    return str_replace(['dev-api', 'stg-api'], 'api', $string) === '(' . (getmypid()) . ') GET: https://api.unzer.com/v1/my/uri/123';
+                    return str_replace(['dev-api', 'stg-api'], 'sbx-api', $string) === '(' . (getmypid()) . ') GET: https://sbx-api.unzer.com/v1/my/uri/123';
                 }
             )
             ],
@@ -223,7 +223,7 @@ class HttpServiceTest extends BasePaymentTest
             ['(' . (getmypid()) . ') Response: (200) {"response":"myResponseString"}'],
             [ $this->callback(
                 static function ($string) {
-                    return str_replace(['dev-api', 'stg-api'], 'api', $string) === '(' . (getmypid()) . ') POST: https://api.unzer.com/v1/my/uri/123';
+                    return str_replace(['dev-api', 'stg-api'], 'sbx-api', $string) === '(' . (getmypid()) . ') POST: https://sbx-api.unzer.com/v1/my/uri/123';
                 }
             )
             ],

--- a/test/unit/Services/HttpServiceTest.php
+++ b/test/unit/Services/HttpServiceTest.php
@@ -394,7 +394,7 @@ class HttpServiceTest extends BasePaymentTest
     }
 
     /**
-     * Verify environment switches accordingly depending on environment variable and keypair defines PAPI environment.
+     * Verify API environment switches accordingly depending on environment variable and keypair.
      *
      * @test
      *
@@ -402,8 +402,9 @@ class HttpServiceTest extends BasePaymentTest
      *
      * @param $environment
      * @param $apiUrl
+     * @param string $key
      */
-    public function environmentUrlSwitchesWithEnvironmentVariable($environment, $apiUrl, $key): void
+    public function environmentUrlSwitchesWithEnvironmentVariable($environment, $apiUrl, string $key): void
     {
         $adapterMock = $this->getMockBuilder(CurlAdapter::class)->setMethods(['init', 'setUserAgent', 'setHeaders', 'execute', 'getResponseCode', 'close'])->getMock();
         /** @noinspection PhpParamsInspection */

--- a/test/unit/UnzerTest.php
+++ b/test/unit/UnzerTest.php
@@ -222,6 +222,20 @@ class UnzerTest extends BasePaymentTest
         $unzer->$unzerMethod(...$unzerParams);
     }
 
+    /**
+     * Verify unzer provides correct environment based on the set key.
+     *
+     * @test
+     */
+    public function unzerShouldProvideExpectedKeyEnvironment()
+    {
+        $unzerProduction = new Unzer('p-priv-abcdef-g');
+        $this->assertEquals(true, $unzerProduction->hasProductionKey());
+
+        $unzerSandbox = new Unzer('s-priv-abcdef-g');
+        $this->assertEquals(false, $unzerSandbox->hasProductionKey());
+    }
+
     //<editor-fold desc="DataProviders">
 
     /**

--- a/test/unit/UnzerTest.php
+++ b/test/unit/UnzerTest.php
@@ -222,20 +222,6 @@ class UnzerTest extends BasePaymentTest
         $unzer->$unzerMethod(...$unzerParams);
     }
 
-    /**
-     * Verify unzer provides correct environment based on the set key.
-     *
-     * @test
-     */
-    public function unzerShouldProvideExpectedKeyEnvironment()
-    {
-        $unzerProduction = new Unzer('p-priv-abcdef-g');
-        $this->assertEquals(true, $unzerProduction->hasProductionKey());
-
-        $unzerSandbox = new Unzer('s-priv-abcdef-g');
-        $this->assertEquals(false, $unzerSandbox->hasProductionKey());
-    }
-
     //<editor-fold desc="DataProviders">
 
     /**


### PR DESCRIPTION
- Implement automatic switch to sbx Api-Url when Sbx-Keypair is used.
- Mark Unzer::setKey as deprecated, since it is safer to use a different unzer object if a different key should be used.