### PR TITLE
(UMCS-631) Add express checkout support, needed for Paypal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres
 to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.3.0](https://github.com/unzerdev/php-sdk/compare/1.2.1.0..1.2.3.0)
+
+### Changed
+
+*   Resource ID fields won't be sent in payment request if they are empty anymore.
+
+### Added
+
+*   Add support for express checkout via PayPal.
+    *   Add support to set `checkoutType` for charge/authorize request.
+    *   Add transaction status `resumed`.
+    *   Add `updateCharge` and `updateAuthorization` method to `Unzer` class
+
 ## [1.2.2.0](https://github.com/unzerdev/php-sdk/compare/1.2.1.0..1.2.2.0)
 
 ### Changed

--- a/src/Adapter/CurlAdapter.php
+++ b/src/Adapter/CurlAdapter.php
@@ -67,7 +67,12 @@ class CurlAdapter implements HttpAdapterInterface
         $this->setOption(CURLOPT_VERBOSE, $curlVerbose);
         $this->setOption(CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
-        if (in_array($httpMethod, [HttpAdapterInterface::REQUEST_POST, HttpAdapterInterface::REQUEST_PUT], true)) {
+        $postFieldMethods = [
+            HttpAdapterInterface::REQUEST_POST,
+            HttpAdapterInterface::REQUEST_PUT,
+            HttpAdapterInterface::REQUEST_PATCH
+        ];
+        if (in_array($httpMethod, $postFieldMethods, true)) {
             $this->setOption(CURLOPT_POSTFIELDS, $payload);
         }
     }

--- a/src/Adapter/HttpAdapterInterface.php
+++ b/src/Adapter/HttpAdapterInterface.php
@@ -26,10 +26,11 @@ use UnzerSDK\Exceptions\UnzerApiException;
 
 interface HttpAdapterInterface
 {
-    public const REQUEST_POST = 'POST';
     public const REQUEST_DELETE = 'DELETE';
-    public const REQUEST_PUT = 'PUT';
     public const REQUEST_GET = 'GET';
+    public const REQUEST_PATCH = 'PATCH';
+    public const REQUEST_POST = 'POST';
+    public const REQUEST_PUT = 'PUT';
 
     /**
      * Initializes the request.

--- a/src/Constants/AdditionalTransactionDataKeys.php
+++ b/src/Constants/AdditionalTransactionDataKeys.php
@@ -27,4 +27,7 @@ class AdditionalTransactionDataKeys
     // Transactions
     public const TERMS_AND_CONDITION_URL = 'termsAndConditionUrl';
     public const PRIVACY_POLICY_URL = 'privacyPolicyUrl';
+
+    // Checkout types
+    public const CHECKOUTTYPE = 'checkoutType';
 }

--- a/src/Constants/TransactionStatus.php
+++ b/src/Constants/TransactionStatus.php
@@ -27,4 +27,5 @@ class TransactionStatus
     public const STATUS_PENDING = 'pending';
     public const STATUS_SUCCESS = 'success';
     public const STATUS_ERROR = 'error';
+    public const STATUS_RESUMED = 'resumed';
 }

--- a/src/Constants/WebhookEvents.php
+++ b/src/Constants/WebhookEvents.php
@@ -29,19 +29,21 @@ class WebhookEvents
 
     // authorize events
     public const AUTHORIZE = 'authorize';
-    public const AUTHORIZE_SUCCEEDED = 'authorize.succeeded';
+    public const AUTHORIZE_CANCELED = 'authorize.canceled';
+    public const AUTHORIZE_EXPIRED = 'authorize.expired';
     public const AUTHORIZE_FAILED = 'authorize.failed';
     public const AUTHORIZE_PENDING = 'authorize.pending';
-    public const AUTHORIZE_EXPIRED = 'authorize.expired';
-    public const AUTHORIZE_CANCELED = 'authorize.canceled';
+    public const AUTHORIZE_RESUMED = 'authorize.resumed';
+    public const AUTHORIZE_SUCCEEDED = 'authorize.succeeded';
 
     // charge events
     public const CHARGE = 'charge';
-    public const CHARGE_SUCCEEDED = 'charge.succeeded';
+    public const CHARGE_CANCELED = 'charge.canceled';
+    public const CHARGE_EXPIRED = 'charge.expired';
     public const CHARGE_FAILED = 'charge.failed';
     public const CHARGE_PENDING = 'charge.pending';
-    public const CHARGE_EXPIRED = 'charge.expired';
-    public const CHARGE_CANCELED = 'charge.canceled';
+    public const CHARGE_RESUMED = 'charge.resumed';
+    public const CHARGE_SUCCEEDED = 'charge.succeeded';
 
     // chargeback events
     public const CHARGEBACK = 'chargeback';
@@ -74,17 +76,19 @@ class WebhookEvents
     public const ALLOWED_WEBHOOKS = [
         self::ALL,
         self::AUTHORIZE,
-        self::AUTHORIZE_SUCCEEDED,
+        self::AUTHORIZE_CANCELED,
+        self::AUTHORIZE_EXPIRED,
         self::AUTHORIZE_FAILED,
         self::AUTHORIZE_PENDING,
-        self::AUTHORIZE_EXPIRED,
-        self::AUTHORIZE_CANCELED,
+        self::AUTHORIZE_RESUMED,
+        self::AUTHORIZE_SUCCEEDED,
         self::CHARGE,
-        self::CHARGE_SUCCEEDED,
+        self::CHARGE_CANCELED,
+        self::CHARGE_EXPIRED,
         self::CHARGE_FAILED,
         self::CHARGE_PENDING,
-        self::CHARGE_EXPIRED,
-        self::CHARGE_CANCELED,
+        self::CHARGE_RESUMED,
+        self::CHARGE_SUCCEEDED,
         self::CHARGEBACK,
         self::PAYOUT,
         self::PAYOUT_SUCCEEDED,

--- a/src/Interfaces/PaymentServiceInterface.php
+++ b/src/Interfaces/PaymentServiceInterface.php
@@ -65,6 +65,21 @@ interface PaymentServiceInterface
     ): Authorization;
 
     /**
+     * Update an Authorization transaction with PATCH method and returns the resulting Authorization resource.
+     *
+     * @param Authorization $authorization The Authorization object containing transaction specific information.
+     * @param Basket|null   $basket        The Basket object corresponding to the payment.
+     *                                     The Basket object will be created automatically if it does not exist
+     *                                     yet (i.e. has no id).
+     *
+     * @return Authorization The resulting object of the Authorization resource.
+     *
+     * @throws UnzerApiException An UnzerApiException is thrown if there is an error returned on API-request.
+     * @throws RuntimeException  A RuntimeException is thrown when there is an error while using the SDK.
+     */
+    public function updateAuthorization(Authorization $authorization, Basket $basket = null): Authorization;
+
+    /**
      * Performs an Authorization transaction and returns the resulting Authorization resource.
      *
      * @deprecated since 1.2.0.0 please use performAuthorization() instead.
@@ -129,6 +144,21 @@ interface PaymentServiceInterface
         $metadata = null,
         $basket = null
     ): Charge;
+
+    /**
+     * Update a Charge transaction with PATCH method and returns the resulting Charge resource.
+     *
+     * @param Charge      $charge The Charge object containing transaction specific information.
+     * @param Basket|null $basket The Basket object corresponding to the payment.
+     *                            The Basket object will be created automatically if it does not exist
+     *                            yet (i.e. has no id).
+     *
+     * @return Charge The resulting object of the Charge resource.
+     *
+     * @throws UnzerApiException An UnzerApiException is thrown if there is an error returned on API-request.
+     * @throws RuntimeException  A RuntimeException is thrown when there is an error while using the SDK.
+     */
+    public function updateCharge(Charge $charge, Basket $basket = null): Charge;
 
     /**
      * Performs a Charge transaction and returns the resulting Charge resource.

--- a/src/Resources/AbstractUnzerResource.php
+++ b/src/Resources/AbstractUnzerResource.php
@@ -535,7 +535,7 @@ abstract class AbstractUnzerResource implements UnzerParentInterface
 
             $properties[$property] = $value;
         }
-    
+
         return $properties;
     }
 
@@ -552,7 +552,10 @@ abstract class AbstractUnzerResource implements UnzerParentInterface
          * @var AbstractUnzerResource $linkedResource
          */
         foreach ($this->getLinkedResources() as $attributeName => $linkedResource) {
-            $exposedResources[$attributeName . 'Id'] = $linkedResource ? $linkedResource->getId() : '';
+            $resourceId = $linkedResource ? $linkedResource->getId() : null;
+            if ($resourceId !== null) {
+                $exposedResources[$attributeName . 'Id'] = $resourceId;
+            }
         }
         return $exposedResources;
     }

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -221,7 +221,11 @@ class HttpService
 
         // log request
         $unzerObj->debugLog($httpMethod . ': ' . $url);
-        $writingOperations = [HttpAdapterInterface::REQUEST_POST, HttpAdapterInterface::REQUEST_PUT];
+        $writingOperations = [
+            HttpAdapterInterface::REQUEST_POST,
+            HttpAdapterInterface::REQUEST_PUT,
+            HttpAdapterInterface::REQUEST_PATCH
+        ];
         $unzerObj->debugLog('Headers: ' . json_encode($headers, JSON_UNESCAPED_SLASHES));
         if (in_array($httpMethod, $writingOperations, true)) {
             $unzerObj->debugLog('Request: ' . $payload);

--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -102,9 +102,21 @@ class PaymentService implements PaymentServiceInterface
 
         $this->getResourceService()->createResource($authorization);
         return $authorization;
-    }/**
+    }
+
+    /**
      * {@inheritDoc}
      */
+    public function updateAuthorization(
+        Authorization $authorization,
+        Basket $basket = null
+    ): Authorization {
+        $paymentResource = $this->getResourceService()->getPaymentResource($authorization->getPayment());
+        $paymentResource->setAuthorization($authorization)
+            ->setBasket($basket);
+        $this->getResourceService()->patchResource($authorization);
+        return $authorization;
+    }
 
     /**
      * {@inheritDoc}
@@ -161,6 +173,19 @@ class PaymentService implements PaymentServiceInterface
 
         $this->getResourceService()->createResource($charge);
 
+        return $charge;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function updateCharge(
+        Charge $charge,
+        Basket $basket = null
+    ): Charge {
+        $paymentResource = $charge->getPayment();
+        $paymentResource->setBasket($basket);
+        $this->getResourceService()->patchResource($charge);
         return $charge;
     }
 

--- a/src/Services/ResourceService.php
+++ b/src/Services/ResourceService.php
@@ -281,6 +281,31 @@ class ResourceService implements ResourceServiceInterface
     }
 
     /**
+     * Update the resource on the api with PATCH method.
+     *
+     * @param AbstractUnzerResource $resource
+     *
+     * @return AbstractUnzerResource
+     *
+     * @throws UnzerApiException An UnzerApiException is thrown if there is an error returned on API-request.
+     * @throws RuntimeException  A RuntimeException is thrown when there is an error while using the SDK.
+     * @throws Exception
+     */
+    public function patchResource(AbstractUnzerResource $resource): AbstractUnzerResource
+    {
+        $method = HttpAdapterInterface::REQUEST_PATCH;
+        $response = $this->send($resource, $method, $resource->getApiVersion());
+
+        $isError = isset($response->isError) && $response->isError;
+        if ($isError) {
+            return $resource;
+        }
+
+        $resource->handleResponse($response, $method);
+        return $resource;
+    }
+
+    /**
      * @param AbstractUnzerResource $resource
      *
      * @return AbstractUnzerResource|null

--- a/src/Traits/HasAdditionalTransactionData.php
+++ b/src/Traits/HasAdditionalTransactionData.php
@@ -27,6 +27,7 @@ use stdClass;
 use UnzerSDK\Constants\AdditionalTransactionDataKeys;
 use UnzerSDK\Resources\EmbeddedResources\RiskData;
 use UnzerSDK\Resources\EmbeddedResources\ShippingData;
+use UnzerSDK\Resources\PaymentTypes\BasePaymentType;
 use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 
 trait HasAdditionalTransactionData
@@ -164,5 +165,36 @@ trait HasAdditionalTransactionData
     {
         $propertyKey = AdditionalTransactionDataKeys::TERMS_AND_CONDITION_URL;
         return $this->getAdditionalTransactionData()->$propertyKey ?? null;
+    }
+
+    /**
+     * Set checkout type based on the given payment Type.
+     *
+     */
+    public function setCheckoutType(BasePaymentType $paymentType, string $checkoutType): self
+    {
+        $this->addAdditionalTransactionData(
+            $paymentType::getResourceName(),
+            (object) [AdditionalTransactionDataKeys::CHECKOUTTYPE => $checkoutType]
+        );
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCheckoutType(): ?string
+    {
+        $additionalTransactionData = $this->getAdditionalTransactionData();
+        if ($additionalTransactionData !== null) {
+            $key = AdditionalTransactionDataKeys::CHECKOUTTYPE;
+            foreach ($additionalTransactionData as $data) {
+                if ($data instanceof stdClass && property_exists($data, $key)) {
+                    return $data->$key ?? null;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Traits/HasStates.php
+++ b/src/Traits/HasStates.php
@@ -36,6 +36,9 @@ trait HasStates
     /** @var bool $isPending */
     private $isPending = false;
 
+    /** @var bool $isResumed */
+    private $isResumed = false;
+
     //<editor-fold desc="Getters/Setters">
 
     /**
@@ -95,6 +98,25 @@ trait HasStates
         return $this;
     }
 
+    /**
+     * @return bool
+     */
+    public function isResumed(): bool
+    {
+        return $this->isResumed;
+    }
+
+    /**
+     * @param bool $isResumed
+     *
+     * @return self
+     */
+    public function setIsResumed(bool $isResumed): self
+    {
+        $this->isResumed = $isResumed;
+        return $this;
+    }
+
     //</editor-fold>
 
     /**
@@ -123,6 +145,9 @@ trait HasStates
             case (TransactionStatus::STATUS_SUCCESS):
                 $this->setIsSuccess(true);
                 break;
+            case (TransactionStatus::STATUS_RESUMED):
+                $this->setIsResumed(true);
+                break;
         }
 
         return $this;
@@ -141,6 +166,7 @@ trait HasStates
             TransactionStatus::STATUS_ERROR,
             TransactionStatus::STATUS_PENDING,
             TransactionStatus::STATUS_SUCCESS,
+            TransactionStatus::STATUS_RESUMED,
         ];
 
         if (!in_array($status, $validStatusArray, true)) {

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -729,6 +729,11 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
         return $this->paymentService->performAuthorization($authorization, $paymentType, $customer, $metadata, $basket);
     }
 
+    public function updateAuthorization(Authorization $authorization, Basket $basket = null): Authorization
+    {
+        return $this->paymentService->updateAuthorization($authorization, $basket);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -772,6 +777,11 @@ class Unzer implements UnzerParentInterface, PaymentServiceInterface, ResourceSe
     public function performCharge(Charge $charge, $paymentType, $customer = null, $metadata = null, $basket = null): Charge
     {
         return $this->paymentService->performCharge($charge, $paymentType, $customer, $metadata, $basket);
+    }
+
+    public function updateCharge(Charge $charge, Basket $basket = null): Charge
+    {
+        return $this->paymentService->updateCharge($charge, $basket);
     }
 
     /**

--- a/test/integration/TransactionTypes/ChargeTest.php
+++ b/test/integration/TransactionTypes/ChargeTest.php
@@ -214,4 +214,24 @@ class ChargeTest extends BaseIntegrationTest
         $fetchedCharge = $this->unzer->fetchChargeById($charge->getPaymentId(), $charge->getId());
         $this->assertEquals($charge->setCard3ds(false)->expose(), $fetchedCharge->expose());
     }
+
+    /**
+     * Verify checkoutType for not supported type gets ignored by Api.
+     *
+     * @test
+     */
+    public function checkoutTypeGetsIgnordedByApiWithNotSupportedType()
+    {
+        $paymentType = $this->unzer->createPaymentType($this->createCardObject());
+        $charge = new Charge(99.99, 'EUR', self::RETURN_URL);
+        $charge->setCheckoutType($paymentType, 'express');
+        $this->getUnzerObject()->performCharge($charge, $paymentType);
+
+        $fetchedCharge = $this->getUnzerObject()->fetchChargeById(
+            $charge->getPayment()->getId(),
+            $charge->getId()
+        );
+        $this->assertTrue($fetchedCharge->isPending());
+        $this->assertNull($fetchedCharge->getCheckoutType());
+    }
 }

--- a/test/unit/Resources/TransactionTypes/AbstractTransactionTypeTest.php
+++ b/test/unit/Resources/TransactionTypes/AbstractTransactionTypeTest.php
@@ -115,6 +115,7 @@ class AbstractTransactionTypeTest extends BasePaymentTest
         $this->assertFalse($transactionType->isSuccess());
         $this->assertFalse($transactionType->isPending());
         $this->assertFalse($transactionType->isError());
+        $this->assertFalse($transactionType->isResumed());
 
         $responseArray = ['status' => TransactionStatus::STATUS_ERROR];
         $transactionType->handleResponse((object)$responseArray);
@@ -122,6 +123,7 @@ class AbstractTransactionTypeTest extends BasePaymentTest
         $this->assertFalse($transactionType->isSuccess());
         $this->assertFalse($transactionType->isPending());
         $this->assertTrue($transactionType->isError());
+        $this->assertFalse($transactionType->isResumed());
 
         $responseArray['status'] = TransactionStatus::STATUS_SUCCESS;
         $transactionType->handleResponse((object)$responseArray);
@@ -129,6 +131,7 @@ class AbstractTransactionTypeTest extends BasePaymentTest
         $this->assertTrue($transactionType->isSuccess());
         $this->assertFalse($transactionType->isPending());
         $this->assertFalse($transactionType->isError());
+        $this->assertFalse($transactionType->isResumed());
 
         $responseArray['status'] = TransactionStatus::STATUS_PENDING;
         $transactionType->handleResponse((object)$responseArray);
@@ -136,6 +139,15 @@ class AbstractTransactionTypeTest extends BasePaymentTest
         $this->assertFalse($transactionType->isSuccess());
         $this->assertTrue($transactionType->isPending());
         $this->assertFalse($transactionType->isError());
+        $this->assertFalse($transactionType->isResumed());
+
+        $responseArray['status'] = TransactionStatus::STATUS_RESUMED;
+        $transactionType->handleResponse((object)$responseArray);
+
+        $this->assertFalse($transactionType->isSuccess());
+        $this->assertFalse($transactionType->isPending());
+        $this->assertFalse($transactionType->isError());
+        $this->assertTrue($transactionType->isResumed());
 
         $this->expectException(\RuntimeException::class);
 

--- a/test/unit/Services/ResourceServiceTest.php
+++ b/test/unit/Services/ResourceServiceTest.php
@@ -253,6 +253,28 @@ class ResourceServiceTest extends BasePaymentTest
     }
 
     /**
+     * Verify patch method will call send method and call the resources handleResponse method with the response.
+     *
+     * @test
+     */
+    public function patchShouldCallSendAndThenHandleResponseWithTheResponseData(): void
+    {
+        $response = new stdClass();
+
+        /** @var Customer|MockObject $testResource */
+        $testResource = $this->getMockBuilder(Charge::class)->setMethods(['handleResponse'])->getMock();
+        /** @noinspection PhpParamsInspection */
+        $testResource->expects($this->once())->method('handleResponse')->with($response, HttpAdapterInterface::REQUEST_PATCH);
+
+        /** @var ResourceService|MockObject $resourceServiceMock */
+        $resourceServiceMock = $this->getMockBuilder(ResourceService::class)->setMethods(['send'])->disableOriginalConstructor()->getMock();
+        /** @noinspection PhpParamsInspection */
+        $resourceServiceMock->expects($this->once())->method('send')->with($testResource, HttpAdapterInterface::REQUEST_PATCH)->willReturn($response);
+
+        $this->assertSame($testResource, $resourceServiceMock->patchResource($testResource));
+    }
+
+    /**
      * Verify update does not handle response with error.
      *
      * @test
@@ -1283,6 +1305,7 @@ class ResourceServiceTest extends BasePaymentTest
     {
         return [
             HttpAdapterInterface::REQUEST_GET    => [HttpAdapterInterface::REQUEST_GET, '/my/get/uri', true],
+            HttpAdapterInterface::REQUEST_PATCH   => [HttpAdapterInterface::REQUEST_PATCH, '/my/patch/uri', true],
             HttpAdapterInterface::REQUEST_POST   => [HttpAdapterInterface::REQUEST_POST, '/my/post/uri', false],
             HttpAdapterInterface::REQUEST_PUT    => [HttpAdapterInterface::REQUEST_PUT, '/my/put/uri', true],
             HttpAdapterInterface::REQUEST_DELETE => [HttpAdapterInterface::REQUEST_DELETE, '/my/delete/uri', true],

--- a/test/unit/Traits/HasAdditionalTransactionDataTest.php
+++ b/test/unit/Traits/HasAdditionalTransactionDataTest.php
@@ -28,6 +28,7 @@ namespace UnzerSDK\test\unit\Traits;
 
 use UnzerSDK\Resources\EmbeddedResources\RiskData;
 use UnzerSDK\Resources\EmbeddedResources\ShippingData;
+use UnzerSDK\Resources\PaymentTypes\Paypal;
 use UnzerSDK\test\BasePaymentTest;
 
 class HasAdditionalTransactionDataTest extends BasePaymentTest
@@ -40,6 +41,12 @@ class HasAdditionalTransactionDataTest extends BasePaymentTest
     public function gettersAndSettersShouldWorkProperly(): void
     {
         $dummy = new TraitDummyHasAdditionalTransactionData();
+
+        $this->assertNull($dummy->getShipping());
+        $this->assertNull($dummy->getRiskData());
+        $this->assertNull($dummy->getPrivacyPolicyUrl());
+        $this->assertNull($dummy->getTermsAndConditionUrl());
+        $this->assertNull($dummy->getCheckoutType());
 
         $shipping = (new ShippingData())
             ->setDeliveryService('deliveryService')
@@ -54,13 +61,14 @@ class HasAdditionalTransactionDataTest extends BasePaymentTest
         $dummy->setShipping($shipping)
             ->setRiskData($riskData)
             ->setPrivacyPolicyUrl($privacyPolicyUrl)
+            ->setCheckoutType(new Paypal(), 'express')
             ->setTermsAndConditionUrl($termsAndConditionUrl);
-
 
         $this->assertNotNull($dummy->getShipping());
         $this->assertNotNull($dummy->getRiskData());
         $this->assertNotNull($dummy->getPrivacyPolicyUrl());
         $this->assertNotNull($dummy->getTermsAndConditionUrl());
+        $this->assertNotNull($dummy->getCheckoutType());
 
         $this->assertEquals($shipping, $dummy->getShipping());
         $this->assertEquals($riskData, $dummy->getRiskData());


### PR DESCRIPTION
- Add support to set `checkoutType` for charge/authorize request.
- Add transaction status `resumed`.
- Add `updateCharge` and `updateAuthorization` method to `Unzer` class