### PR TITLE
(UMCS-676) Remove invoice id from general cancel test, since response…

### DIFF
--- a/test/integration/TransactionTypes/CancelTest.php
+++ b/test/integration/TransactionTypes/CancelTest.php
@@ -79,7 +79,7 @@ class CancelTest extends BaseIntegrationTest
     public function refundShouldBeFetchableViaPaymentObject(): void
     {
         $charge = $this->createCharge();
-        $cancel = (new Cancellation())->setInvoiceId('i' . self::generateRandomId());
+        $cancel = new Cancellation();
         $this->getUnzerObject()->cancelChargedPayment($charge->getPayment(), $cancel);
         $fetchedCancel = $cancel->getPayment()->getCharge($charge->getId())->getCancellation($cancel->getId());
         $this->assertTransactionResourceHasBeenCreated($fetchedCancel);


### PR DESCRIPTION
… does not contain invoiceId.