### PR TITLE
Prevent null access when setting special params

### DIFF
--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -150,7 +150,7 @@ class PaymentService implements PaymentServiceInterface
         $paymentType = $payment->getPaymentType();
 
         /** @var Charge $charge */
-        $charge->setSpecialParams($paymentType->getTransactionParams() ?? []);
+        $charge->setSpecialParams(is_null($paymentType) ? [] : $paymentType->getTransactionParams());
         $payment->addCharge($charge)->setCustomer($customer)->setMetadata($metadata)->setBasket($basket);
 
         $this->getResourceService()->createResource($charge);


### PR DESCRIPTION
The old version only checks if getTransactionParams() is null but not if $paymentType itself is null. If $paymentType is null, the old code would have caused an error (calling method on null). The new version first checks if $paymentType is set and returns an empty array if not.