### PR TITLE
Add mapping for openbankingpis to work with PayPageV2

### DIFF
--- a/src/Resources/EmbeddedResources/Paypage/PaymentMethodsConfigs.php
+++ b/src/Resources/EmbeddedResources/Paypage/PaymentMethodsConfigs.php
@@ -11,6 +11,7 @@ class PaymentMethodsConfigs extends AbstractUnzerResource
     const PAYPAGE_TYPE_NAME_MAPPING = [
         'card' => 'cards',
         'eps' => 'eps',
+        'openbankingpis' => 'openbankingpis',
         'payu' => 'payu',
         'postfinanceefinance' => 'pfefinance',
         'postfinancecard' => 'pfcard'


### PR DESCRIPTION
This change is needed to add a payment method config entry for openbanking pis according to the docs.
https://docs.unzer.com/online-payments/payment-pages/payment-pages-v2/integrate-epp-v2/#exclude-payment-methods

Without this change it will fail with this error:
`responseCode":"40000","responseMessage":"Bad request","fieldErrors":[{"field":"paymentMethodsConfigs.openbankingPis","message":"unknown field"}]`
