### PR TITLE
[CC-2379] Fix fatal error when payment type is null in performCharge and performSca

### DIFF
--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -157,7 +157,7 @@ class PaymentService implements PaymentServiceInterface
         $paymentType = $payment->getPaymentType();
 
         /** @var Charge $charge */
-        $charge->setSpecialParams($paymentType->getTransactionParams() ?? []);
+        $charge->setSpecialParams($paymentType?->getTransactionParams() ?? []);
         $payment->addCharge($charge)->setCustomer($customer)->setMetadata($metadata)->setBasket($basket);
 
         $this->getResourceService()->createResource($charge);
@@ -417,7 +417,7 @@ class PaymentService implements PaymentServiceInterface
         $paymentType = $payment->getPaymentType();
 
         /** @var Sca $sca */
-        $sca->setSpecialParams($paymentType->getTransactionParams() ?? []);
+        $sca->setSpecialParams($paymentType?->getTransactionParams() ?? []);
         $payment->setSca($sca)->setCustomer($customer)->setMetadata($metadata)->setBasket($basket);
 
         $this->getResourceService()->createResource($sca);

--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -86,7 +86,7 @@ class PaymentService implements PaymentServiceInterface
     ): Authorization {
         $payment = $this->createPayment($paymentType);
         $paymentType = $payment->getPaymentType();
-        $authorization->setSpecialParams($paymentType !== null ? $paymentType->getTransactionParams() : []);
+        $authorization->setSpecialParams($paymentType?->getTransactionParams() ?? []);
 
         $payment->setAuthorization($authorization)
             ->setCustomer($customer)

--- a/test/unit/Services/PaymentServiceTest.php
+++ b/test/unit/Services/PaymentServiceTest.php
@@ -291,11 +291,15 @@ class PaymentServiceTest extends BasePaymentTest
      */
     public function performChargeWithNullPaymentTypeShouldNotThrowFatalError(): void
     {
-        $this->expectNotToPerformAssertions();
         $resourceSrvMock = $this->getMockBuilder(ResourceService::class)->disableOriginalConstructor()->setMethods(['createResource'])->getMock();
         $paymentSrv = (new Unzer('s-priv-123'))->setResourceService($resourceSrvMock)->getPaymentService();
 
-        $paymentSrv->performCharge(new Charge(), null);
+        try {
+            $paymentSrv->performCharge(new Charge(), null);
+            $this->assertTrue(true);
+        } catch (\Throwable $e) {
+            $this->fail('performCharge threw an unexpected error: ' . $e->getMessage());
+        }
     }
 
     /**
@@ -305,11 +309,15 @@ class PaymentServiceTest extends BasePaymentTest
      */
     public function performScaWithNullPaymentTypeShouldNotThrowFatalError(): void
     {
-        $this->expectNotToPerformAssertions();
         $resourceSrvMock = $this->getMockBuilder(ResourceService::class)->disableOriginalConstructor()->setMethods(['createResource'])->getMock();
         $paymentSrv = (new Unzer('s-priv-123'))->setResourceService($resourceSrvMock)->getPaymentService();
 
-        $paymentSrv->performSca(new Sca(), null);
+        try {
+            $paymentSrv->performSca(new Sca(), null);
+            $this->assertTrue(true);
+        } catch (\Throwable $e) {
+            $this->fail('performSca threw an unexpected error: ' . $e->getMessage());
+        }
     }
 
     //</editor-fold>

--- a/test/unit/Services/PaymentServiceTest.php
+++ b/test/unit/Services/PaymentServiceTest.php
@@ -31,6 +31,7 @@ use UnzerSDK\Resources\TransactionTypes\Authorization;
 use UnzerSDK\Resources\TransactionTypes\Cancellation;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use UnzerSDK\Resources\TransactionTypes\Payout;
+use UnzerSDK\Resources\TransactionTypes\Sca;
 use UnzerSDK\Resources\TransactionTypes\Shipment;
 use UnzerSDK\Services\CancelService;
 use UnzerSDK\Services\PaymentService;
@@ -281,6 +282,34 @@ class PaymentServiceTest extends BasePaymentTest
         $paymentSrv     = $unzer->setResourceService($resourceSrvMock)->getPaymentService();
         $returnedCharge = $paymentSrv->chargePayment($payment, 1.234, 'orderId', 'invoiceId');
         $this->assertEquals([$returnedCharge], $payment->getCharges());
+    }
+
+    /**
+     * Verify performCharge does not throw a fatal error when the payment type resolves to null.
+     *
+     * @test
+     */
+    public function performChargeWithNullPaymentTypeShouldNotThrowFatalError(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $resourceSrvMock = $this->getMockBuilder(ResourceService::class)->disableOriginalConstructor()->setMethods(['createResource'])->getMock();
+        $paymentSrv = (new Unzer('s-priv-123'))->setResourceService($resourceSrvMock)->getPaymentService();
+
+        $paymentSrv->performCharge(new Charge(), null);
+    }
+
+    /**
+     * Verify performSca does not throw a fatal error when the payment type resolves to null.
+     *
+     * @test
+     */
+    public function performScaWithNullPaymentTypeShouldNotThrowFatalError(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $resourceSrvMock = $this->getMockBuilder(ResourceService::class)->disableOriginalConstructor()->setMethods(['createResource'])->getMock();
+        $paymentSrv = (new Unzer('s-priv-123'))->setResourceService($resourceSrvMock)->getPaymentService();
+
+        $paymentSrv->performSca(new Sca(), null);
     }
 
     //</editor-fold>


### PR DESCRIPTION
## Summary

- Fixes a fatal `TypeError` (`Call to a member function getTransactionParams() on null`) in `performCharge` and `performSca` when the payment type resolves to `null` after `$payment->getPaymentType()`
- Replaces the plain method call with PHP 8's nullsafe operator (`?->`) so a null payment type safely short-circuits to `[]`, while preserving the existing `?? []` fallback for when `getTransactionParams()` itself returns `null`
- Adds unit tests for both methods covering the null payment type case

Closes #207