### PR TITLE
[CC-3981] Fix Paypage requests broken by internal keyClassMap leaking into serialized payload

### DIFF
--- a/src/Resources/AbstractUnzerResource.php
+++ b/src/Resources/AbstractUnzerResource.php
@@ -501,6 +501,11 @@ abstract class AbstractUnzerResource implements UnzerParentInterface
 
         $properties = [];
         foreach ($reflectionProperties as $propertyObject) {
+            // static properties are internal to the class and must never be sent to the API
+            if ($propertyObject->isStatic()) {
+                continue;
+            }
+
             $property = $propertyObject->getName();
             $value = $propertyObject->getValue($this);
 

--- a/src/Resources/AbstractUnzerResource.php
+++ b/src/Resources/AbstractUnzerResource.php
@@ -501,7 +501,6 @@ abstract class AbstractUnzerResource implements UnzerParentInterface
 
         $properties = [];
         foreach ($reflectionProperties as $propertyObject) {
-            // static properties are internal to the class and must never be sent to the API
             if ($propertyObject->isStatic()) {
                 continue;
             }

--- a/src/Resources/V2/Paypage.php
+++ b/src/Resources/V2/Paypage.php
@@ -22,7 +22,7 @@ class Paypage extends AbstractUnzerResource
 {
     public const URI = '/merchant/paypage';
 
-    protected static $keyClassMap = [
+    private static $keyClassMap = [
         'urls' => Urls::class,
         'style' => Style::class,
         'resources' => Resources::class,

--- a/test/integration/Resources/BasketV2Test.php
+++ b/test/integration/Resources/BasketV2Test.php
@@ -212,7 +212,7 @@ class BasketV2Test extends BaseIntegrationTest
 
         /** @var Paypal $paypal */
         $paypal = $this->unzer->createPaymentType(new Paypal());
-        $authorize = $paypal->authorize(123.4, 'EUR', 'https://unzer.com', null, null, null, $basket);
+        $authorize = $paypal->authorize(99.99, 'EUR', 'https://unzer.com', null, null, null, $basket);
 
         $fetchedPayment = $this->unzer->fetchPayment($authorize->getPaymentId());
         $this->assertEquals($basket->expose(), $fetchedPayment->getBasket()->expose());
@@ -261,7 +261,7 @@ class BasketV2Test extends BaseIntegrationTest
 
         /** @var Paypal $paypal */
         $paypal = $this->unzer->createPaymentType(new Paypal());
-        $authorize = $paypal->authorize(123.4, 'EUR', 'https://unzer.com', null, null, null, $basket);
+        $authorize = $paypal->authorize(99.99, 'EUR', 'https://unzer.com', null, null, null, $basket);
         $this->assertNotEmpty($basket->getId());
 
         $fetchedPayment = $this->unzer->fetchPayment($authorize->getPaymentId());
@@ -290,7 +290,7 @@ class BasketV2Test extends BaseIntegrationTest
 
         /** @var Paypal $paypal */
         $paypal = $this->unzer->createPaymentType(new Paypal());
-        $charge = $paypal->charge(123.4, 'EUR', 'https://unzer.com', null, null, null, $basket);
+        $charge = $paypal->charge(99.99, 'EUR', 'https://unzer.com', null, null, null, $basket);
         $this->assertNotEmpty($basket->getId());
 
         $fetchedPayment = $this->unzer->fetchPayment($charge->getPaymentId());

--- a/test/integration/Resources/BasketV3Test.php
+++ b/test/integration/Resources/BasketV3Test.php
@@ -220,7 +220,7 @@ class BasketV3Test extends BaseIntegrationTest
 
         /** @var Paypal $paypal */
         $paypal = $this->unzer->createPaymentType(new Paypal());
-        $authorize = $paypal->authorize(123.4, 'EUR', 'https://unzer.com', null, null, null, $basket);
+        $authorize = $paypal->authorize(99.99, 'EUR', 'https://unzer.com', null, null, null, $basket);
 
         $fetchedPayment = $this->unzer->fetchPayment($authorize->getPaymentId());
         $this->assertEquals($basket->expose(), $fetchedPayment->getBasket()->expose());
@@ -248,7 +248,7 @@ class BasketV3Test extends BaseIntegrationTest
 
         /** @var Paypal $paypal */
         $paypal = $this->unzer->createPaymentType(new Paypal());
-        $authorize = $paypal->authorize(123.4, 'EUR', 'https://unzer.com', null, null, null, $basket);
+        $authorize = $paypal->authorize(99.99, 'EUR', 'https://unzer.com', null, null, null, $basket);
         $this->assertNotEmpty($basket->getId());
 
         $fetchedPayment = $this->unzer->fetchPayment($authorize->getPaymentId());
@@ -277,7 +277,7 @@ class BasketV3Test extends BaseIntegrationTest
 
         /** @var Paypal $paypal */
         $paypal = $this->unzer->createPaymentType(new Paypal());
-        $charge = $paypal->charge(123.4, 'EUR', 'https://unzer.com', null, null, null, $basket);
+        $charge = $paypal->charge(99.99, 'EUR', 'https://unzer.com', null, null, null, $basket);
         $this->assertNotEmpty($basket->getId());
 
         $fetchedPayment = $this->unzer->fetchPayment($charge->getPaymentId());

--- a/test/integration/Resources/PaypageV2Test.php
+++ b/test/integration/Resources/PaypageV2Test.php
@@ -76,7 +76,8 @@ class PaypageV2Test extends BaseIntegrationTest
 
         $this->assertNull($paypage->getUrls());
         $this->assertNull($paypage->getStyle());
-        $this->assertNull($paypage->getResources());
+        $this->assertNull($paypage->getResources()->getCustomerId());
+        $this->assertNull($paypage->getResources()->getBasketId());
         $this->assertNull($paypage->getPaymentMethodsConfigs());
         $this->assertNull($paypage->getRisk());
     }
@@ -271,6 +272,7 @@ class PaypageV2Test extends BaseIntegrationTest
     {
         $this->assertNotNull($paypage->getId());
         $this->assertNotNull($paypage->getRedirectUrl());
+        $this->assertNotNull($paypage->getResources()->getMetadataId());
         $this->assertStringContainsString($paypage->getId(), $paypage->getRedirectUrl());
     }
 


### PR DESCRIPTION
## Summary
- `Paypage` (V2) requests were failing because the internal `$keyClassMap` static lookup table was being serialized into the outgoing API request body.
- Root cause: PR #206 refactored `AbstractUnzerResource::exposeProperties()` to select properties via `ReflectionClass::getProperties(ReflectionProperty::IS_PROTECTED)`, which filters purely on visibility and does not exclude static properties. `Paypage::$keyClassMap` (`protected static`) was picked up and exposed alongside real instance properties.
- Fix: `exposeProperties()` now skips any `isStatic()` property, so no static property (on any resource, present or future) can leak into a request again. Additionally tightened `Paypage::$keyClassMap` to `private` as defense-in-depth, since it is only used internally within the class.
- Audited the rest of the SDK — no other class has a `protected static` property, so `Paypage` was the only resource affected.
- Also fixing some failing failing test data.

Jira: CC-3981

## Dependencies
None.