### PR TITLE
[CC-3789] Release 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres
 to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.2](https://github.com/unzerdev/php-sdk/compare/4.0.1..4.0.2)
+
+### Changed
+
+* Change `\UnzerSDK\Resources\Keypair` properties from `private` to `protected`, fixing them being silently omitted when the resource is serialized into a request payload.
+* Add a null check for the payment type in `performCharge()` and `performSca()` in `\UnzerSDK\Unzer` to avoid a null pointer error.
+
 ## [4.0.1](https://github.com/unzerdev/php-sdk/compare/4.0.0..4.0.1)
 
 ### Changed

--- a/src/Unzer.php
+++ b/src/Unzer.php
@@ -60,7 +60,7 @@ class Unzer implements
     public const BASE_URL = 'api.unzer.com';
     public const API_VERSION = ApiVersions::V1;
     public const SDK_TYPE = 'UnzerPHP';
-    public const SDK_VERSION = '4.0.1';
+    public const SDK_VERSION = '4.0.2';
 
     /** @var string $key */
     private $key;


### PR DESCRIPTION
## Summary
- Bump `SDK_VERSION` to `4.0.2` in `src/Unzer.php`
- Add `4.0.2` changelog entry:
  - Change `\UnzerSDK\Resources\Keypair` properties from `private` to `protected`, fixing them being silently omitted when the resource is serialized into a request payload.
  - Add a null check for the payment type in `performCharge()` and `performSca()` in `\UnzerSDK\Unzer` to avoid a null pointer error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)